### PR TITLE
Patch reports for ss3.1 compatibility

### DIFF
--- a/code/reports/CustomerReport.php
+++ b/code/reports/CustomerReport.php
@@ -36,20 +36,16 @@ class CustomerReport extends ShopPeriodReport{
 	
 	function query($params){
 		$query = parent::query($params);
-		$query->select(
-			"$this->periodfield AS FilterPeriod",
-			"Member.ID",
-			"Member.FirstName","Member.Surname","Member.Email",
-			"NumVisit","Member.Created",
-			"Count(Order.ID) AS Orders",
-			"Sum(Order.Total) AS Spent"
-		);
-		$query->innerJoin("Order", "Member.ID = Order.MemberID");
-		$query->groupby("Member.ID");
-		if(!$query->orderby){
-			$query->orderby("Spent DESC,Orders DESC");
+		$query->selectField($this->periodfield, "FilterPeriod")
+			->addSelect(array("Member.ID", "Member.FirstName", "Member.Surname", "Member.Email", "NumVisit", "Member.Created"))
+			->selectField("Count(Order.ID)", "Orders")
+			->selectField("Sum(Order.Total)", "Spent");
+		$query->addInnerJoin("Order", "Member.ID = Order.MemberID");
+		$query->addGroupBy("Member.ID");
+		if(!$query->getOrderBy()){
+			$query->setOrderBy("Spent DESC,Orders DESC");
 		}
-		$query->limit("50");
+		$query->setLimit("50");
 		return $query;
 	}
 

--- a/code/reports/ProductReport.php
+++ b/code/reports/ProductReport.php
@@ -9,7 +9,7 @@ class ProductReport extends ShopPeriodReport{
 		
 	function getReportField(){
 		$reportfield = parent::getReportField();
-		$reportfield->setShowPagination(true);
+		$reportfield->getConfig()->removeComponentsByType('GridFieldPaginator');
 		return $reportfield;
 	}
 	
@@ -26,27 +26,27 @@ class ProductReport extends ShopPeriodReport{
 		);
 	}
 	
-	function sourceQuery($params){
+	function query($params){
 		$query = parent::query($params);
-		$query->select(
-			"$this->periodfield AS FilterPeriod",
-			"Product.ID",
-			"SiteTree.ClassName",
-			"SiteTree.Title",
-			"Product.BasePrice",
-			"SiteTree.Created",
-			"Count(OrderItem.Quantity) AS Quantity",
-			"Sum(OrderAttribute.CalculatedTotal) AS Sales"
-		);
-		$query->innerJoin("SiteTree","Product.ID = SiteTree.ID");
-		$query->leftJoin("Product_OrderItem","Product.ID = Product_OrderItem.ProductID");
-		$query->leftJoin("OrderItem","Product_OrderItem.ID = OrderItem.ID");
-		$query->leftJoin("OrderAttribute","Product_OrderItem.ID = OrderAttribute.ID");
-		$query->leftJoin("Order","OrderAttribute.OrderID = Order.ID");
-		$query->groupby("Product.ID");
-		$query->where("\"Order\".\"Paid\" IS NOT NULL OR \"Product_OrderItem\".\"ID\" IS NULL");
-		if(!$query->orderby){
-			$query->orderby("Sales DESC");
+		$query->selectField($this->periodfield, "FilterPeriod")
+			->addSelect(array(
+				"Product.ID",
+				"SiteTree.ClassName",
+				"SiteTree.Title",
+				"Product.BasePrice",
+				"SiteTree.Created",
+			))
+			->selectField("Count(OrderItem.Quantity)", "Quantity")
+			->selectField("Sum(OrderAttribute.CalculatedTotal)", "Sales");
+		$query->addInnerJoin("SiteTree","Product.ID = SiteTree.ID");
+		$query->addLeftJoin("Product_OrderItem","Product.ID = Product_OrderItem.ProductID");
+		$query->addLeftJoin("OrderItem","Product_OrderItem.ID = OrderItem.ID");
+		$query->addLeftJoin("OrderAttribute","Product_OrderItem.ID = OrderAttribute.ID");
+		$query->addLeftJoin("Order","OrderAttribute.OrderID = Order.ID");
+		$query->addGroupby("Product.ID");
+		$query->addWhere("\"Order\".\"Paid\" IS NOT NULL OR \"Product_OrderItem\".\"ID\" IS NULL");
+		if(!$query->getOrderBy()){
+			$query->setOrderBy("Sales DESC");
 		}
 		return $query;
 	}

--- a/code/reports/ShopPeriodReport.php
+++ b/code/reports/ShopPeriodReport.php
@@ -49,7 +49,7 @@ class ShopPeriodReport extends SS_Report{
 	
 	function getReportField(){
 		$field = parent::getReportField();
-		$field->setShowPagination(false);
+		$field->getConfig()->removeComponentsByType('GridFieldPaginator');
 		return $field;
 	}
 	
@@ -77,46 +77,46 @@ class ShopPeriodReport extends SS_Report{
 	
 	function query($params){
 		$query = new ShopReport_Query();
-		$query->select("$this->periodfield AS FilterPeriod");
-		$query->from("\"$this->dataClass\"");
+		$query->selectField($this->periodfield, 'FilterPeriod');
+		$query->setFrom('"' . $this->dataClass . '"');
 		$start = isset($params['StartPeriod']) && !empty($params['StartPeriod']) ? date('Y-m-d',strtotime($params["StartPeriod"])) : null;
 		$end = isset($params['EndPeriod']) && !empty($params['EndPeriod']) ? date('Y-m-d',strtotime($params["EndPeriod"]) + 86400) : null; //end day is inclusive
 		if($start && $end){
-			$query->having("FilterPeriod BETWEEN '$start' AND '$end'");
+			$query->addHaving("FilterPeriod BETWEEN '$start' AND '$end'");
 		}elseif($start){
-			$query->having("FilterPeriod > '$start'");
+			$query->addHaving("FilterPeriod > '$start'");
 		}elseif($end){
-			$query->having("FilterPeriod <= '$end'");
+			$query->addHaving("FilterPeriod <= '$end'");
 		}
 		if($start || $end){
-			$query->having("FilterPeriod IS NOT NULL"); //only include paid orders when we are doing specific period searching
+			$query->addHaving("FilterPeriod IS NOT NULL"); //only include paid orders when we are doing specific period searching
 		}
 		if($this->grouping){
 			switch($params['Grouping']){
 				case "Year":
-					$query->groupby("YEAR(FilterPeriod)");
+					$query->addGroupBy("YEAR(FilterPeriod)");
 					break;
 				case "Month":
 				default:
-					$query->groupby("YEAR(FilterPeriod),MONTH(FilterPeriod)");
+					$query->addGroupBy("YEAR(FilterPeriod),MONTH(FilterPeriod)");
 					break;
 				case "Week":
-					$query->groupby("YEAR(FilterPeriod),WEEK(FilterPeriod)");
+					$query->addGroupBy("YEAR(FilterPeriod),WEEK(FilterPeriod)");
 					break;
 				case "Day":
-					$query->limit("0,1000");
-					$query->groupby("YEAR(FilterPeriod),MONTH(FilterPeriod),DAY(FilterPeriod)");
+					$query->setLimit("0,1000");
+					$query->addGroupBy("YEAR(FilterPeriod),MONTH(FilterPeriod),DAY(FilterPeriod)");
 					break;
 			}
 		}
 		if(isset($params["ctf"]["ReportContent"]["sort"])){
 			$dir = isset($params["ctf"]["ReportContent"]["dir"]) ? $params["ctf"]["ReportContent"]["dir"] : "DESC";
-			$query->orderby($params["ctf"]["ReportContent"]["sort"]." $dir");
+			$query->addOrderBy($params["ctf"]["ReportContent"]["sort"], $dir);
 		}
 		if(isset($params["ctf"]["ReportContent"]["start"])){
-			$query->limit($params["ctf"]["ReportContent"]["start"].",".$this->pagesize);
+			$query->setLimit($params["ctf"]["ReportContent"]["start"].",".$this->pagesize);
 		}else{
-			$query->limit($this->pagesize);
+			$query->setLimit($this->pagesize);
 		}
 		return $query;
 	}

--- a/code/reports/ShopSalesReport.php
+++ b/code/reports/ShopSalesReport.php
@@ -18,11 +18,12 @@ class ShopSalesReport extends ShopPeriodReport{
 		
 	function getReportField(){
 		$reportfield = parent::getReportField();
-		$reportfield->setShowPagination(false);
-		$reportfield->addSummary("Totals",array(
-			"Sales" => array("sum","Currency->Nice"),
-			//"Count" => array("sum","Currency->Nice") //Not working! (TableListField error, when enabled)
-		));
+		$reportfield->getConfig()->removeComponentsByType('GridFieldPaginator');
+		// TODO: Add this back in - I'm not sure how this works in Gridfield
+//		$reportfield->addSummary("Totals",array(
+//			"Sales" => array("sum","Currency->Nice"),
+//			//"Count" => array("sum","Currency->Nice") //Not working! (TableListField error, when enabled)
+//		));
 		//TODO: add averages (not working, because you can't have more than one summary row)
 		return $reportfield;
 	}
@@ -37,12 +38,10 @@ class ShopSalesReport extends ShopPeriodReport{
 	
 	function query($params){
 		$query = parent::query($params);
-		$query->select(
-			"$this->periodfield AS FilterPeriod",
-			"Count(Order.ID) AS Count",
-			"Sum(Order.Total) AS Sales"
-		);
-		$query->where("\"Order\".\"Paid\" IS NOT NULL");
+		$query->selectField($this->periodfield, "FilterPeriod")
+			->selectField("Count(Order.ID)", "Count")
+			->selectField("Sum(Order.Total)", "Sales");
+		$query->setWhere("\"Order\".\"Paid\" IS NOT NULL");
 		return $query;
 	}
 	

--- a/code/reports/ShopSideReport.php
+++ b/code/reports/ShopSideReport.php
@@ -17,11 +17,13 @@ class ShopSideReport_FeaturedProducts extends SS_Report {
 	function group() {
 		return _t('ShopSideReport.ShopGROUP', "Shop");
 	}
+
 	function sort() {
 		return 0;
 	}
-	function records($params = null) {
-		return DataObject::get("Product", "\"FeaturedProduct\" = 1", "\"Title\"");
+
+	function sourceRecords($params = null) {
+		return Product::get()->filter('FeaturedProduct', 1)->sort("Title");
 	}
 
 	function columns() {
@@ -50,8 +52,9 @@ class ShopSideReport_AllProducts extends SS_Report {
 	function sort() {
 		return 0;
 	}
-	function records($params = null) {
-		return DataObject::get("Product", "", "\"Title\"");
+
+	function sourceRecords($params = null) {
+		return Product::get()->sort('Title');
 	}
 
 	function columns() {
@@ -77,7 +80,7 @@ class ShopSideReport_NoImageProducts extends SS_Report {
 		return 0;
 	}
 	function sourceRecords($params = null) {
-		return DataObject::get("Product", "\"Product\".\"ImageID\" IS NULL OR \"Product\".\"ImageID\" <= 0", "\"Title\" ASC");
+		return Product::get()->where("\"Product\".\"ImageID\" IS NULL OR \"Product\".\"ImageID\" <= 0")->sort("\"Title\" ASC");
 	}
 	function columns() {
 		return array(
@@ -101,7 +104,7 @@ class ShopSideReport_HeavyProducts extends SS_Report {
 		return 0;
 	}
 	function sourceRecords($params = null) {
-		return DataObject::get("Product", "\"Product\".\"Weight\" > 10", "\"Weight\" ASC");
+		return Product::get()->where("\"Product\".\"Weight\" > 10")->sort("\"Weight\" ASC");
 	}
 	function columns() {
 		return array(


### PR DESCRIPTION
Removed deprecated method calls to SQLQuery (e.g. replacing innerJoin with addInnerJoin). I believe these were fine in 3.0 but began throwing warnings in 3.1.
