### PR TITLE
Remove old FixVersioned

### DIFF
--- a/code/variations/ProductVariation.php
+++ b/code/variations/ProductVariation.php
@@ -204,7 +204,7 @@ class ProductVariation_OrderItem extends Product_OrderItem {
 	 */
 	public function ProductVariation($forcecurrent = false) {
 		if($this->ProductVariationID && $this->ProductVariationVersion && !$forcecurrent){
-			return FixVersioned::get_version('ProductVariation', $this->ProductVariationID, $this->ProductVariationVersion);
+			return Versioned::get_version('ProductVariation', $this->ProductVariationID, $this->ProductVariationVersion);
 		}elseif($this->ProductVariationID && $product = DataObject::get_by_id('ProductVariation', $this->ProductVariationID)){
 			return $product;
 		}


### PR DESCRIPTION
We should be ok doing this yes? and why is Git wanting to replace whole file all the time?

see line: 207:
return FixVersioned::get_version('ProductVariation', $this->ProductVariationID, $this->ProductVariationVersion);

should just be 
return Versioned::get_version('ProductVariation', $this->ProductVariationID, $this->ProductVariationVersion);

maybe
