### PR TITLE
Fix to popularity calculation returns null if product was bought today.

### DIFF
--- a/code/tasks/CalculateProductPopularity.php
+++ b/code/tasks/CalculateProductPopularity.php
@@ -25,9 +25,9 @@ class CalculateProductPopularity extends BuildTask{
 		foreach(array("_Live","") as $stage){
 			$sql =<<<SQL
 				UPDATE "Product$stage" SET "Popularity" = (
-					SELECT 
-						SUM(1 / DATEDIFF(NOW(),Order.Paid)) * SUM(`OrderItem`.`Quantity`)
-						#	/ DATEDIFF(SiteTree$stage.Created,NOW()) 
+					SELECT
+						SUM(1 / (DATEDIFF(NOW(),Order.Paid)+1)) * SUM(`OrderItem`.`Quantity`)
+						#	/ DATEDIFF(SiteTree$stage.Created,NOW())
 						AS Popularity
 					FROM "SiteTree$stage"
 						INNER JOIN "Product_OrderItem" ON "SiteTree$stage"."ID" = "Product_OrderItem"."ProductID"


### PR DESCRIPTION
If a product was purchased on the same day as the task is run, `DATEDIFF(NOW(),Order.Paid)` returns 0, resulting in a div-by-zero error.
