### PR TITLE
Sorting for Price - should be BasePrice

### DIFF
--- a/code/products/ProductCategory.php
+++ b/code/products/ProductCategory.php
@@ -35,7 +35,7 @@ class ProductCategory extends Page {
 	//TODO: allow grouping multiple sort fields under one 'sort option', and allow choosing direction of each
 	protected static $sort_options = array(
 		'URLSegment' => 'Alphabetical',
-		'Price' => 'Lowest Price',
+		'BasePrice' => 'Lowest Price',
 		//'NumberSold' => 'Most Popular'
 		//'Featured' => 'Featured',
 		//'Weight' => 'Weight'


### PR DESCRIPTION
The link for sorting products by lowest price gives an error, the field name is not Price but BasePrice
