### PR TITLE
Fixed Image function if variation deleted

### DIFF
--- a/code/product/variations/ProductVariation.php
+++ b/code/product/variations/ProductVariation.php
@@ -220,7 +220,7 @@ class ProductVariation_OrderItem extends Product_OrderItem {
 	}
 	
 	public function Image(){
-		if($this->ProductVariation()->Image()->exists()){
+		if(($this->ProductVariation()) && $this->ProductVariation()->Image()->exists()){
 			return $this->ProductVariation()->Image();
 		}
 		return $this->Product()->Image();


### PR DESCRIPTION
If a admin removes a variation from the CMS but a customer still has the variation in their Cart the image function would fail because calling $this->ProductVariation()->Image() if $this->ProductVariation() does not exist.
