### PR TITLE
If only one payment method fix

### DIFF
--- a/code/checkout/components/PaymentCheckoutComponent.php
+++ b/code/checkout/components/PaymentCheckoutComponent.php
@@ -15,6 +15,11 @@ class PaymentCheckoutComponent extends CheckoutComponent{
 				)
 			);
 		}
+		if(count($gateways) == 1){
+			$fields->push(
+				HiddenField::create('PaymentMethod')->setValue(key($gateways))
+			);
+		}
 
 		return $fields;
 	}


### PR DESCRIPTION
If there is only one payment method the submission fails because PaymentMethod does not exist.

fixed by creating a hidden field if only one payment method
