### PR TITLE
API Fixed CartCleanupTask, define time in mins rather than relative

### DIFF
--- a/tests/tasks/CartCleanupTaskTest.php
+++ b/tests/tasks/CartCleanupTaskTest.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * @package shop
+ * @subpackage tests
+ */
+
+class CartCleanupTaskTest extends SapphireTest {
+
+	public function setUp() {
+		parent::setUp();
+
+		Config::nest();
+		Config::inst()->update('CartCleanupTask', 'delete_after_mins', 120);
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+
+		Config::unnest();
+	}
+
+	public function testRun() {
+		SS_Datetime::set_mock_now('2014-01-31 13:00:00');
+
+		// less than two hours old
+		$orderRunningRecent = new Order(array('Status' => 'Cart'));
+		$orderRunningRecentID = $orderRunningRecent->write();
+		DB::query('UPDATE "ORDER" SET "LastEdited" = \'2014-01-31 12:30:00\' WHERE "ID" = ' . $orderRunningRecentID);
+
+		// three hours old
+		$orderRunningOld = new Order(array('Status' => 'Cart'));
+		$orderRunningOldID = $orderRunningOld->write();
+		DB::query('UPDATE "ORDER" SET "LastEdited" = \'2014-01-31 10:00:00\' WHERE "ID" = ' . $orderRunningOldID);
+
+		// three hours old
+		$orderPaidOld = new Order(array('Status' => 'Paid'));
+		$orderPaidOldID = $orderPaidOld->write();
+		DB::query('UPDATE "ORDER" SET "LastEdited" = \'2014-01-31 10:00:00\' WHERE "ID" = ' . $orderPaidOldID);
+
+		$task = new CartCleanupTaskTest_CartCleanupTaskFake();
+		$response = $task->run(new SS_HTTPRequest('GET', '/'));
+
+		$this->assertInstanceOf('Order', Order::get()->byID($orderRunningRecentID));
+		$this->assertNull(Order::get()->byID($orderRunningOldID));
+		$this->assertInstanceOf('Order', Order::get()->byID($orderPaidOldID));
+
+		$this->assertEquals('1 old carts removed.', $task->log[count($task->log)-1]);
+
+		SS_Datetime::clear_mock_now();
+	}
+
+}
+
+class CartCleanupTaskTest_CartCleanupTaskFake extends CartCleanupTask {
+
+	public $log = array();
+
+	public function log($msg) {
+		$this->log[] = $msg;
+	}
+
+}


### PR DESCRIPTION
Relative time is prone to errors. Case in point:

```
With a current date of 2014-05-27 13:05:21
php -r 'var_dump(date("Y-m-d H:m:i",strtotime("-2 hours")));'
string(19) "2014-05-27 11:05:21"
php -r 'var_dump(date("Y-m-d H:m:i",strtotime("-2 hrs")));'
string(19) "2014-05-28 03:05:21"
```

This would delete ALL of your pending orders because of a typo.

Also fixed the task itself, it plainly wasn't working (undefined $cart etc).
Didn't want to introduce a mocking library into the project, so written
a small fake as a simple subclass in unit tests.
