### PR TITLE
API Mark Order.Paid=<date> on $allow_zero_order_total

### DIFF
--- a/code/checkout/OrderProcessor.php
+++ b/code/checkout/OrderProcessor.php
@@ -144,7 +144,13 @@ class OrderProcessor{
 			if($this->canPlace($this->order)){
 				$this->placeOrder();
 			}
-			if($this->order->GrandTotal() > 0 && $this->order->TotalOutstanding() <= 0){
+
+			if(
+				// Standard order
+				($this->order->GrandTotal() > 0 && $this->order->TotalOutstanding() <= 0)
+				// Zero-dollar order (e.g. paid with loyalty points)
+				|| ($this->order->GrandTotal() == 0 && Order::config()->allow_zero_order_total)
+			){
 				//set order as paid
 				$this->order->Status = 'Paid';
 				$this->order->Paid = SS_Datetime::now()->Rfc2822();
@@ -205,7 +211,7 @@ class OrderProcessor{
 		if($this->order->TotalOutstanding()){
 			$this->order->Status = 'Unpaid';
 		}else{
-			$this->order->Status = 'Processing';
+			$this->order->Status = 'Paid';
 		}
 		if(!$this->order->Placed){
 			$this->order->Placed = SS_Datetime::now()->Rfc2822(); //record placed order datetime

--- a/code/checkout/PaymentForm.php
+++ b/code/checkout/PaymentForm.php
@@ -70,10 +70,10 @@ class PaymentForm extends CheckoutForm{
 		$order = $this->config->getOrder();
 		//final recalculation, before making payment
 		$order->calculate();
-		//handle cases where order total is 0
+		//handle cases where order total is 0. Note that the order will appear
+		//as "paid", but without a Payment record attached.
 		if($order->GrandTotal() == 0 && Order::config()->allow_zero_order_total){
 			if($this->orderProcessor->placeOrder()){
-
 				return $this->controller->redirect($this->getSuccessLink());
 			}
 			//TODO: store error for display?

--- a/code/model/Order.php
+++ b/code/model/Order.php
@@ -122,7 +122,17 @@ class Order extends DataObject {
 	private static $modifiers = array();
 
 	private static $rounding_precision = 2;
+
 	private static $reference_id_padding = 5;
+
+	/**
+	 * @var boolean Will allow completion of orders with GrandTotal=0,
+	 * which could be the case for orders paid with loyalty points or vouchers.
+	 * Will send the "Paid" date on the order, even though no actual payment was taken.
+	 * Will trigger the payment related extension points:
+	 * Order->onPayment, OrderItem->onPayment, Order->onPaid.
+	 */
+	private static $allow_zero_order_total = false;
 
 	public static function get_order_status_options() {
 		return singleton('Order')->dbObject('Status')->enumValues(false);


### PR DESCRIPTION
Otherwise the onPayment hooks aren't called, which can lead to inconsistencies in treating orders (e.g. failing to send a valid zero dollar order to a warehouse for processing). "Payment" can consist of more than just a credit card transaction, a voucher which fully covers the order should also be considered payment (@halkyon agrees with this, and @madmatt is on the fence).

Also sets Order.Status='Paid' rather than 'Processing', which is more accurate. The 'Processing' status is described as follows: "Order paid for, package is currently being processed before shipping to customer". This does not apply automatically for zero dollar orders, there's no correlation between an order for zero dollars and the fact that its processed or not.
