### PR TITLE
Fixing case where add_session_order() isn't called on $0 orders

### DIFF
--- a/code/checkout/OrderProcessor.php
+++ b/code/checkout/OrderProcessor.php
@@ -63,9 +63,6 @@ class OrderProcessor{
 		$service = PurchaseService::create($payment)
 					->setReturnUrl($this->getReturnUrl());
 
-		// Save order reference to session
-		OrderManipulation::add_session_order($this->order);
-
 		// Process payment, get the result back
 		$response = $service->purchase($this->getGatewayData($gatewaydata));
 		if(GatewayInfo::is_manual($gateway)){
@@ -240,6 +237,10 @@ class OrderProcessor{
 		//allow decorators to do stuff when order is saved.
 		$this->order->extend('onPlaceOrder');
 		$this->order->write();
+
+		// Save order reference to session
+		OrderManipulation::add_session_order($this->order);
+
 		return true; //report success
 	}
 


### PR DESCRIPTION
Direct result is the confirmation page shows a 404, it can't match
a requested order to an ID stored in session.

This fixes that by moving OrderManipulation::add_session_order() call
into placeOrder() instead of makePayment(), so that it's always set
regardless of whether a payment was made or not.

Can you think of a reason why it was only set in makePayment?
