### PR TITLE
Set Order->Paid date alongside Order->Status consistently

### DIFF
--- a/code/checkout/OrderProcessor.php
+++ b/code/checkout/OrderProcessor.php
@@ -209,6 +209,7 @@ class OrderProcessor{
 			$this->order->Status = 'Unpaid';
 		}else{
 			$this->order->Status = 'Paid';
+			$this->order->Paid = SS_Datetime::now()->Rfc2822();
 		}
 		if(!$this->order->Placed){
 			$this->order->Placed = SS_Datetime::now()->Rfc2822(); //record placed order datetime

--- a/tests/checkout/OrderProcessorTest.php
+++ b/tests/checkout/OrderProcessorTest.php
@@ -113,6 +113,29 @@ class OrderProcessorTest extends SapphireTest {
 		//$this->assertEquals($order->Member()->Password, Security::encrypt_password('jbrown'),'password matches');
 	}
 
+	public function testPlaceOrderMarksAsPaidWithNoOutstandingAmount() {
+		$orderStub = $this->getMockBuilder('Order')
+			->setMethods(array('TotalOutstanding'))
+			->getMock();
+
+		// Set up test state
+		$orderStub->expects($this->any())
+			 ->method('TotalOutstanding')
+			 ->will($this->returnValue(0));
+		$processorStub = $this->getMockBuilder('OrderProcessor')
+			->setConstructorArgs(array($orderStub))
+			->setMethods(array('canPlace'))
+			->getMock();
+		$processorStub->expects($this->any())
+			 ->method('canPlace')
+			 ->will($this->returnValue(true));
+
+		$processorStub->placeOrder();
+
+		$this->assertNotNull($orderStub->Paid, 'Sets paid date');
+		$this->assertEquals('Paid', $orderStub->Status, 'Sets paid status');
+	}
+
 	public function testMemberOrder() {
 		//log out the admin user
 		Member::currentUser()->logOut();


### PR DESCRIPTION
I've mistakenly pushed an unfinished commit to upstream/master rather than origin/master two days ago, which broke the shop builds (see https://travis-ci.org/burnbright/silverstripe-shop/builds/29288119 and http://take.ms/g3rej). I've since removed that commit from upstream by force pushing the previous revision. Sorry about that!

What do you think of the usage of PHPUnit mocks? I much prefer the https://github.com/padraic/mockery syntax, PHPUnit's is very counter intuitive. But its built-in, and does the job here - means I need to make assumptions about a limited amount of internal behaviour on the object (e.g. setting `TotalOutstanding` manually), but it keeps cause and effect relatively close to each other, only one level deep into the tested code. And don't need to build up massive state just to test one isolated feature like setting the paid date.