### PR TITLE
Fix recursive ChildCategories on ProductCategory

### DIFF
--- a/code/product/ProductCategory.php
+++ b/code/product/ProductCategory.php
@@ -76,12 +76,12 @@ class ProductCategory extends Page {
 	 * @return DataList
 	 */
 	public function ChildCategories($recursive = false) {
-		$children = ProductCategory::get()->filter("ParentID",$this->ID);
+		$ids = array($this->ID);
 		if($recursive){
-			$children = $children->filter("ParentID",$this->AllChildCategoryIDs());
+			$ids += $this->AllChildCategoryIDs();
 		}
 
-		return $children;
+		return ProductCategory::get()->filter("ParentID", $ids);
 	}
 
 	/**


### PR DESCRIPTION
ChildCategories was doing (ParentID = $this->ID) AND (ParentID in ($childIDs))
As a page can't have two parents, it fails to correctly load the child categories. Changed it to load the current id, and any child ids into an array and use this for the filter.
