### PR TITLE
UNFINISHED: saved cards

### DIFF
--- a/code/checkout/CheckoutConfig.php
+++ b/code/checkout/CheckoutConfig.php
@@ -5,4 +5,7 @@ class CheckoutConfig extends Object{
 	private static $member_creation_enabled = true;
 	private static $membership_required = false;
 
+    /** @var bool - automatically save (tokenized) cards if available in the gateway */
+    private static $save_credit_cards = false;
+
 }

--- a/code/checkout/OrderProcessor.php
+++ b/code/checkout/OrderProcessor.php
@@ -95,7 +95,7 @@ class OrderProcessor{
 			CheckoutConfig::config()->save_credit_cards &&
 			GatewayInfo::can_save_cards($payment->Gateway)
 		) {
-			if (empty($data['SavedCreditCardID'])) {
+			if (empty($data['SavedCreditCardID']) || $data['SavedCreditCardID'] == 'newcard') {
 				// NOTE: This will create a SavedCreditCard record and associate it with the Payment
 				return SavedCardService::create($payment)->createCard($data);
 			} else {

--- a/code/checkout/OrderProcessor.php
+++ b/code/checkout/OrderProcessor.php
@@ -87,14 +87,14 @@ class OrderProcessor{
      *
      * @param Payment $payment
      * @param array $data
-     * @return GatewayResponse|null
+     * @return \Omnipay\Common\Message\ResponseInterface|null
      */
     protected function saveCardIfNeeded($payment, $data) {
         if (
             $payment &&
             empty($data['SavedCardID']) &&
             CheckoutConfig::config()->save_credit_cards &&
-            GatewayInfo::can_save_cards($payment->getGatewayTitle())
+            GatewayInfo::can_save_cards($payment->Gateway)
         ) {
             // NOTE: This will create a SavedCreditCard record and associate it with the Payment
             return SavedCardService::create($payment)->createCard($data);

--- a/code/checkout/components/AddressBookCheckoutComponent.php
+++ b/code/checkout/components/AddressBookCheckoutComponent.php
@@ -7,12 +7,26 @@
  */
 abstract class AddressBookCheckoutComponent extends AddressCheckoutComponent{
 
+	private static $composite_field_tag = 'div';
+
 	public function getFormFields(Order $order) {
 		$fields = parent::getFormFields($order);
+
 		if($existingaddressfields = $this->getExistingAddressFields()){
+			Requirements::javascript('shop/javascript/CheckoutPage.js');
+
+			// add the fields for a new address after the dropdown field
 			$existingaddressfields->merge($fields);
 
-			return $existingaddressfields;
+			// group under a composite field (invisible by default) so we
+			// easily know which fields to show/hide
+			$label = _t("AddressBookCheckkoutComponent.{$this->addresstype}Address", "{$this->addresstype} Address");
+			return new FieldList(
+				CompositeField::create($existingaddressfields)
+					->addExtraClass('hasExistingValues')
+					->setLegend($label)
+					->setTag(Config::inst()->get('AddressBookCheckoutComponent', 'composite_field_tag'))
+			);
 		}
 
 		return $fields;
@@ -28,21 +42,79 @@ abstract class AddressBookCheckoutComponent extends AddressCheckoutComponent{
 			$addressoptions = $member->AddressBook()->sort('Created', 'DESC')->map('ID', 'toString')->toArray();
 			$addressoptions['newaddress'] = 'Create new address';
 			$fieldtype = count($addressoptions) > 3 ? 'DropdownField' : 'OptionsetField';
+			$label = _t("AddressBookCheckoutComponent.Existing{$this->addresstype}Address", "Existing {$this->addresstype} Address");
 			return new FieldList(
-				$fieldtype::create($this->addresstype."AddressID", "Existing Address",
+				$fieldtype::create($this->addresstype."AddressID", $label,
 					$addressoptions,
 					$member->{"Default".$this->addresstype."AddressID"}
-				)
+				)->addExtraClass('existingValues')
 			);
 		}
 
 		return null;
 	}
 
-	public function validateData(Order $order, array $data) {
-		//TODO: if existing address selected, check that it exists in $member->AddressBook
+	/**
+	 * We don't know at the front end which fields are required so we defer to validateData
+	 * @param Order $order
+	 * @return array
+	 */
+	public function getRequiredFields(Order $order) {
+		return array();
 	}
 
+
+	/**
+	 * @param Order $order
+	 * @param array $data
+	 * @throws ValidationException
+	 */
+	public function validateData(Order $order, array $data) {
+		$result = new ValidationResult();
+		$existingID = !empty($data[$this->addresstype."AddressID"]) ? (int)$data[$this->addresstype."AddressID"] : 0;
+
+		if ($existingID) {
+			// If existing address selected, check that it exists in $member->AddressBook
+			if (!Member::currentUserID() || !Member::currentUser()->AddressBook()->byID($existingID)) {
+				$result->error("Invalid address supplied", $this->addresstype."AddressID");
+				throw new ValidationException($result);
+			}
+		} else {
+			// Otherwise, require the normal address fields
+			$required = parent::getRequiredFields($order);
+			foreach ($required as $fieldName) {
+				if (empty($data[$fieldName])) {
+					$errorMessage = _t(
+						'Form.FIELDISREQUIRED',
+						'{name} is required',
+						array('name' => $fieldName)
+					);
+
+					$result->error($errorMessage, $fieldName);
+					throw new ValidationException($result);
+				}
+			}
+		}
+
+	}
+
+	/**
+	 * Create a new address if the existing address has changed, or is not yet
+	 * created.
+	 *
+	 * @param Order $order order to get addresses from
+	 * @param array $data  data to set
+	 */
+	public function setData(Order $order, array $data) {
+		$existingID = !empty($data[$this->addresstype."AddressID"]) ? (int)$data[$this->addresstype."AddressID"] : 0;
+		if ($existingID > 0) {
+			$order->{$this->addresstype."AddressID"} = $existingID;
+			$order->write();
+			$order->extend('onSet'.$this->addresstype.'Address', $address);
+		} else {
+			parent::setData($order, $data);
+		}
+	}
 }
 
 class ShippingAddressBookCheckoutComponent extends AddressBookCheckoutComponent{

--- a/code/checkout/components/OnsitePaymentCheckoutComponent.php
+++ b/code/checkout/components/OnsitePaymentCheckoutComponent.php
@@ -8,9 +8,6 @@ use Omnipay\Common\Helper;
  */
 class OnsitePaymentCheckoutComponent extends CheckoutComponent {
 
-    /** @var bool - automatically save cards if available in the gateway */
-    private static $save_credit_cards = false;
-
     /** @var string - some might want this to be a fieldset? */
     private static $composite_field_tag = 'div';
 
@@ -31,7 +28,7 @@ class OnsitePaymentCheckoutComponent extends CheckoutComponent {
         // add existing cards if present and allowed
         if (
             GatewayInfo::can_save_cards($gateway) &&
-            Config::inst()->get('OnsitePaymentCheckoutComponent', 'save_credit_cards') &&
+            Config::inst()->get('CheckoutConfig', 'save_credit_cards') &&
             $existingCardFields = $this->getExistingCardsFields()
         ) {
             Requirements::javascript('shop/javascript/CheckoutPage.js');

--- a/code/checkout/components/OnsitePaymentCheckoutComponent.php
+++ b/code/checkout/components/OnsitePaymentCheckoutComponent.php
@@ -8,8 +8,18 @@ use Omnipay\Common\Helper;
  */
 class OnsitePaymentCheckoutComponent extends CheckoutComponent {
 
+    /** @var bool - automatically save cards if available in the gateway */
+    private static $save_credit_cards = false;
+
+    /** @var string - some might want this to be a fieldset? */
+    private static $composite_field_tag = 'div';
+
+    /** @var bool - set in getFormFields, used in validation methods */
+    protected $hasExistingCards = false;
+
+
 	public function getFormFields(Order $order) {
-		$gateway = Checkout::get($order)->getSelectedPaymentMethod();
+		$gateway = $this->getGateway($order);
 		$gatewayfieldsfactory = new GatewayFieldsFactory($gateway, array('Card'));
 		$fields = $gatewayfieldsfactory->getCardFields();
 		if($gateway === "Dummy"){
@@ -18,14 +28,59 @@ class OnsitePaymentCheckoutComponent extends CheckoutComponent {
 			));
 		}
 
+        // add existing cards if present and allowed
+        if (
+            GatewayInfo::can_save_cards($gateway) &&
+            Config::inst()->get('OnsitePaymentCheckoutComponent', 'save_credit_cards') &&
+            $existingCardFields = $this->getExistingCardsFields()
+        ) {
+            Requirements::javascript('shop/javascript/CheckoutPage.js');
+
+            // add the fields for a new address after the dropdown field
+            $existingCardFields->merge($fields);
+
+            // group under a composite field (invisible by default) so we
+            // easily know which fields to show/hide
+            $label = _t("OnsitePaymentCheckoutComponent.CreditCardContainer", "Payment Details");
+            return new FieldList(
+                CompositeField::create($existingCardFields)
+                    ->addExtraClass('hasExistingValues')
+                    ->setLegend($label)
+                    ->setTag(Config::inst()->get('OnsitePaymentCheckoutComponent', 'composite_field_tag'))
+            );
+        }
+
 		return $fields;
 	}
 
 	public function getRequiredFields(Order $order) {
-		return GatewayInfo::required_fields(Checkout::get($order)->getSelectedPaymentMethod());
+		return GatewayInfo::required_fields( $this->getGateway($order) );
 	}
 
-	public function validateData(Order $order, array $data) {
+    /**
+     * Allow choosing from an existing credit cards
+     * @return FieldList|null fields for
+     */
+    public function getExistingCardsFields() {
+        $member = Member::currentUser();
+        if($member && $member->SavedCreditCards()->exists()){
+            $this->hasExistingCards = true;
+            $cardOptions = $member->SavedCreditCards()->sort('Created', 'DESC')->map('ID', 'Name')->toArray();
+            $cardOptions['newcard'] = _t('OnsitePaymentCheckoutComponent.CreateNewCard', 'Create a new card');
+            $fieldtype = count($cardOptions) > 3 ? 'DropdownField' : 'OptionsetField';
+            $label = _t("OnsitePaymentCheckoutComponent.ExistingCards", "Existing Credit Cards");
+            return new FieldList(
+                $fieldtype::create("SavedCreditCardID", $label,
+                    $cardOptions,
+                    $member->DefaultCreditCardID
+                )->addExtraClass('existingValues')
+            );
+        }
+
+        return null;
+    }
+
+    public function validateData(Order $order, array $data) {
 		$result = new ValidationResult();
 		//TODO: validate credit card data
 		if(!Helper::validateLuhn($data['number'])){
@@ -36,7 +91,7 @@ class OnsitePaymentCheckoutComponent extends CheckoutComponent {
 
 	public function getData(Order $order) {
 		$data = array();
-		$gateway = Checkout::get($order)->getSelectedPaymentMethod();
+		$gateway = $this->getGateway($order);
 		//provide valid dummy credit card data
 		if($gateway === "Dummy"){
 			$data = array_merge(array(
@@ -52,4 +107,11 @@ class OnsitePaymentCheckoutComponent extends CheckoutComponent {
 		//create payment?
 	}
 
+    /**
+     * @param Order $order
+     * @return string
+     */
+    protected function getGateway(Order $order) {
+        return Checkout::get($order)->getSelectedPaymentMethod();
+    }
 }

--- a/code/model/ShopMember.php
+++ b/code/model/ShopMember.php
@@ -7,12 +7,14 @@
 class ShopMember extends DataExtension {
 
 	private static $has_many = array(
-		'AddressBook' => 'Address'
+		'AddressBook' => 'Address',
+        'SavedCreditCards' => 'SavedCreditCard',
 	);
 
 	private static $has_one = array(
 		'DefaultShippingAddress' => 'Address',
-		'DefaultBillingAddress' => 'Address'
+		'DefaultBillingAddress' => 'Address',
+        'DefaultCreditCard' => 'SavedCreditCard',
 	);
 
 	/**

--- a/javascript/CheckoutPage.js
+++ b/javascript/CheckoutPage.js
@@ -1,5 +1,16 @@
 (function($){
-	$(window).load(function() {
+	$(document).ready(function() {
+
+		// Configuration defaults
+		if (typeof(window.ShopConfig) != 'object') window.ShopConfig = {};
+		if (typeof(window.ShopConfig.Checkout) != 'object') window.ShopConfig.Checkout = {};
+		window.ShopConfig.Checkout = $.extend({
+			showFieldAnimation: 'fadeIn',
+			hideFieldAnimation: 'fadeOut',
+		}, window.ShopConfig.Checkout);
+
+
+		// Payment checkout component (selecting a payment method)
 		var paymentInputs = $('#PaymentMethod input[type=radio]');
 		var methodFields = $('div.paymentfields');
 		
@@ -15,5 +26,37 @@
 			methodFields.hide();
 			$('#MethodFields_' + $(this).attr('value')).show();
 		});
+
+
+		// Addressbook checkout component
+		// This handles a dropdown or radio buttons containing existing addresses or payment methods,
+		// with one of the options being "create a new ____". When that last option is selected, the
+		// other fields need to be shown, otherwise they need to be hidden.
+		function onExistingValueChange(){
+			$('.hasExistingValues').each(function(idx, container){
+				// visible if the value is not an ID (numeric)
+				var toggleState = isNaN(parseInt($('.existingValues select, .existingValues input:checked', container).val()));
+				var toggleMethod = toggleState ? ShopConfig.Checkout.showFieldAnimation : ShopConfig.Checkout.hideFieldAnimation;
+				var toggleFields = $(container).find('.field').not('.existingValues');
+
+				// animate the fields
+				if (toggleFields && toggleFields.length > 0) {
+					if (typeof(toggleMethod) == 'object') {
+						toggleFields.animate(toggleMethod, 'fast', 'swing');
+					} else {
+						toggleFields[toggleMethod]('fast', 'swing');
+					}
+				}
+
+				// clear them out
+				toggleFields.find('input, select, textarea').val('').prop('disabled', toggleState ? '' : 'disabled');
+			});
+		}
+
+		$('.existingValues select').on('change', onExistingValueChange);
+		$('.existingValues input[type=radio]').on('click', onExistingValueChange);
+
+		onExistingValueChange(); // handle initial state
+
 	});
 })(jQuery);

--- a/tests/checkout/AddressBookCheckoutComponentTest.php
+++ b/tests/checkout/AddressBookCheckoutComponentTest.php
@@ -1,0 +1,108 @@
+<?php
+
+class AddressBookCheckoutComponentTest extends SapphireTest {
+
+	protected static $fixture_file = array(
+		'shop/tests/fixtures/Orders.yml',
+		'shop/tests/fixtures/ShopMembers.yml',
+	);
+
+	/** @var Order $cart */
+	protected $cart;
+
+	/** @var Member $member */
+	protected $member;
+
+	/** @var Address $address1 */
+	protected $address1;
+
+	/** @var Address $address2 */
+	protected $address2;
+
+	/** @var CheckoutComponentConfig $config */
+	protected $config;
+
+	protected $fixtureNewAddress = array(
+		'BillingAddressBookCheckoutComponent_BillingAddressID' => 'newaddress',
+		'BillingAddressBookCheckoutComponent_Country' => 'US',
+		'BillingAddressBookCheckoutComponent_Address' => '123 Test St',
+		'BillingAddressBookCheckoutComponent_AddressLine2' => 'Apt 4',
+		'BillingAddressBookCheckoutComponent_City' => 'Siloam Springs',
+		'BillingAddressBookCheckoutComponent_State' => 'AR',
+		'BillingAddressBookCheckoutComponent_PostalCode' => '72761',
+		'BillingAddressBookCheckoutComponent_Phone' => '11231231234',
+	);
+
+	public function setUp() {
+		ShopTest::setConfiguration();
+		CheckoutConfig::config()->membership_required = false;
+		parent::setUp();
+
+		$this->member   = $this->objFromFixture("Member", "jeremyperemy");
+		$this->cart     = $this->objFromFixture("Order", "cart1");
+		$this->address1 = $this->objFromFixture("Address", "address1");
+		$this->address2 = $this->objFromFixture("Address", "address2");
+		$this->config   = new CheckoutComponentConfig($this->cart, true);
+
+		$this->config->addComponent( new BillingAddressBookCheckoutComponent() );
+
+		$this->address1->MemberID = $this->member->ID;
+		$this->address1->write();
+	}
+
+	public function testCreateNewAddress() {
+		$this->assertTrue(
+			$this->config->validateData($this->fixtureNewAddress)
+		);
+	}
+
+	public function testIncompleteNewAddress() {
+		$this->setExpectedException('ValidationException');
+		$data = $this->fixtureNewAddress;
+		$data['BillingAddressBookCheckoutComponent_Country'] = '';
+
+		$this->config->validateData($data);
+	}
+
+	public function testUseExistingAddress() {
+		$this->member->logIn();
+		$this->assertTrue(
+			$this->config->validateData(array(
+				'BillingAddressBookCheckoutComponent_BillingAddressID' => $this->address1->ID,
+			))
+		);
+	}
+
+	public function testShouldRejectExistingIfNotLoggedIn() {
+		$this->setExpectedException('ValidationException');
+		$this->assertTrue(
+			$this->config->validateData(array(
+				'BillingAddressBookCheckoutComponent_BillingAddressID' => $this->address1->ID,
+			))
+		);
+	}
+
+	public function testShouldRejectExistingIfNotOwnedByMember() {
+		$this->setExpectedException('ValidationException');
+		$this->member->logIn();
+		$this->address1->MemberID = 0;
+		$this->address1->write();
+
+		$this->assertTrue(
+			$this->config->validateData(array(
+				'BillingAddressBookCheckoutComponent_BillingAddressID' => $this->address1->ID,
+			))
+		);
+	}
+
+	public function testShouldNotCreateBlankAddresses() {
+		$beforeCount = Address::get()->count();
+		$this->config->setData(array(
+			'BillingAddressBookCheckoutComponent_BillingAddressID' => $this->address1->ID
+		));
+
+		$this->assertEquals($this->cart->BillingAddressID , $this->address1->ID);
+		$this->assertEquals($beforeCount, Address::get()->count());
+	}
+
+}

--- a/tests/checkout/OnsitePaymentCheckoutComponentTest.php
+++ b/tests/checkout/OnsitePaymentCheckoutComponentTest.php
@@ -30,9 +30,9 @@ class OnsitePaymentCheckoutComponentTest extends SapphireTest {
 	public function setUp() {
 		ShopTest::setConfiguration();
 		CheckoutConfig::config()->membership_required = false;
+        CheckoutConfig::config()->save_credit_cards = true;
         Config::inst()->remove('Payment', 'allowed_gateways');
         Config::inst()->update('Payment', 'allowed_gateways', array('Stripe'));
-        Config::inst()->update('OnsitePaymentCheckoutComponent', 'save_credit_cards', true);
 		parent::setUp();
 
 		$this->member   = $this->objFromFixture("Member", "jeremyperemy");

--- a/tests/checkout/OnsitePaymentCheckoutComponentTest.php
+++ b/tests/checkout/OnsitePaymentCheckoutComponentTest.php
@@ -1,0 +1,77 @@
+<?php
+
+class OnsitePaymentCheckoutComponentTest extends SapphireTest {
+
+	protected static $fixture_file = array(
+		'shop/tests/fixtures/Orders.yml',
+		'shop/tests/fixtures/ShopMembers.yml',
+	);
+
+	/** @var Order $cart */
+	protected $cart;
+
+	/** @var Member $member */
+	protected $member;
+
+	/** @var CheckoutComponentConfig $config */
+	protected $config;
+
+	public function setUp() {
+		ShopTest::setConfiguration();
+		CheckoutConfig::config()->membership_required = false;
+        Config::inst()->remove('Payment', 'allowed_gateways');
+        Config::inst()->update('Payment', 'allowed_gateways', array('Stripe'));
+        Config::inst()->update('OnsitePaymentCheckoutComponent', 'save_credit_cards', true);
+		parent::setUp();
+
+		$this->member   = $this->objFromFixture("Member", "jeremyperemy");
+		$this->cart     = $this->objFromFixture("Order", "cart1");
+		$this->config   = new CheckoutComponentConfig($this->cart, false);
+		$this->config->addComponent( new OnsitePaymentCheckoutComponent() );
+	}
+
+    public function testDefaultFields() {
+        $fields = $this->config->getFormFields();
+        $this->assertNull( $fields->fieldByName('SavedCreditCardID') );
+        $this->assertNotNull( $fields->fieldByName('number') );
+    }
+
+    public function testSaveCreditCardsFlag() {
+        Config::inst()->update('OnsitePaymentCheckoutComponent', 'save_credit_cards', false);
+        $this->member->logIn();
+        $this->makeTestSavedCard();
+        $this->makeTestSavedCard();
+
+        $fields = $this->config->getFormFields();
+        $this->assertNull( $fields->fieldByName('SavedCreditCardID') );
+        $this->assertNotNull( $fields->fieldByName('number') );
+    }
+
+    public function testSavedCards() {
+        $this->member->logIn();
+        $card1 = $this->makeTestSavedCard();
+        $card2 = $this->makeTestSavedCard();
+
+        $fields = $this->config->getFormFields();
+        $fields = $fields->first()->getChildren(); // when existing fields are present, this is wrapped in a composite field
+        $this->assertNotNull( $fields->fieldByName('number') );
+
+        /** @var DropdownField $dd */
+        $dd = $fields->fieldByName('SavedCreditCardID');
+        $this->assertNotNull($dd);
+        $this->assertEquals(3, count($dd->getSource()));
+        $this->assertArrayHasKey('newcard', $dd->getSource());
+        $this->assertArrayHasKey($card1->ID, $dd->getSource());
+        $this->assertArrayHasKey($card2->ID, $dd->getSource());
+    }
+
+    protected function makeTestSavedCard() {
+        $card = new SavedCreditCard();
+        $card->CardReference = uniqid('TEST');
+        $card->LastFourDigits = substr($card->CardReference, -4);
+        $card->UserID = $this->member->ID;
+        $card->write();
+        return $card;
+    }
+
+}


### PR DESCRIPTION
This is submitted for discussion. It corresponds to and requires: https://github.com/burnbright/silverstripe-omnipay/pull/63. It also is branched off of https://github.com/burnbright/silverstripe-shop/pull/269 - sorry if that's confusing. No action is required at this time. I'll submit a final PR once the work is complete and tested. Comments welcome @jedateach, @halkyon, or @chillu (or anyone really).

Basically, this work would not change anything unless:
1. You are using a gateway that supports createCard
2. You set CheckoutConfig.save_credit_cards to true

If both of those conditions are met, it functions exactly like the addressbook does. It of course only stores the last 4 digits of the card and a card reference token.
