### PR TITLE
Added hooks for ajax integration (relates to #232)

### DIFF
--- a/code/cart/ShoppingCart.php
+++ b/code/cart/ShoppingCart.php
@@ -416,6 +416,12 @@ class ShoppingCart_Controller extends Controller{
 		return "";
 	}
 
+
+	/**
+	 * This is used here and in VariationForm and AddProductForm
+	 * @param bool|string $status
+	 * @return bool
+	 */
 	public static function direct($status = true) {
 		if(Director::is_ajax()){
 			return $status;
@@ -434,6 +440,10 @@ class ShoppingCart_Controller extends Controller{
 		$this->cart = ShoppingCart::singleton();
 	}
 
+
+	/**
+	 * @return Product|ProductVariation|Buyable
+	 */
 	protected function buyableFromRequest() {
 		$request = $this->getRequest();
 		if(SecurityToken::is_enabled() && !SecurityToken::inst()->checkRequest($request)){
@@ -465,41 +475,78 @@ class ShoppingCart_Controller extends Controller{
 		return $buyable;
 	}
 
+
+	/**
+	 * Action: add item to cart
+	 * @param SS_HTTPRequest $request
+	 * @return SS_HTTPResponse
+	 */
 	public function add($request) {
-		if($product = $this->buyableFromRequest()){
+		if ($product = $this->buyableFromRequest()) {
 			$quantity = (int) $request->getVar('quantity');
 			if(!$quantity) $quantity = 1;
 			$this->cart->add($product, $quantity, $request->getVars());
 		}
-		return self::direct();
+
+		$this->extend('updateAddResponse', $request, $response, $product, $quantity);
+		return $response ? $response : self::direct();
 	}
 
+	/**
+	 * Action: remove a certain number of items from the cart
+	 * @param SS_HTTPRequest $request
+	 * @return SS_HTTPResponse
+	 */
 	public function remove($request) {
-		if($product = $this->buyableFromRequest()){
+		if ($product = $this->buyableFromRequest()) {
 			$this->cart->remove($product, $quantity = 1, $request->getVars());
 		}
-		return self::direct();
+
+		$this->extend('updateRemoveResponse', $request, $response, $product, $quantity);
+		return $response ? $response : self::direct();
 	}
 
+	/**
+	 * Action: remove all of an item from the cart
+	 * @param SS_HTTPRequest $request
+	 * @return SS_HTTPResponse
+	 */
 	public function removeall($request) {
-		if($product = $this->buyableFromRequest()){
+		if ($product = $this->buyableFromRequest()) {
 			$this->cart->remove($product, null, $request->getVars());
 		}
-		return self::direct();
+
+		$this->extend('updateRemoveAllResponse', $request, $response, $product);
+		return $response ? $response : self::direct();
 	}
 
+
+	/**
+	 * Action: update the quantity of an item in the cart
+	 * @param $request
+	 * @return AjaxHTTPResponse|bool
+	 */
 	public function setquantity($request) {
 		$product = $this->buyableFromRequest();
 		$quantity = (int) $request->getVar('quantity');
-		if($product){
+		if ($product) {
 			$this->cart->setQuantity($product, $quantity, $request->getVars());
 		}
-		return self::direct();
+
+		$this->extend('updateSetQuantityResponse', $request, $response, $product, $quantity);
+		return $response ? $response : self::direct();
 	}
 
+
+	/**
+	 * Action: clear the cart
+	 * @param $request
+	 * @return AjaxHTTPResponse|bool
+	 */
 	public function clear($request) {
 		$this->cart->clear();
-		return self::direct();
+		$this->extend('updateClearResponse', $request, $response);
+		return $response ? $response : self::direct();
 	}
 
 	/**

--- a/code/product/variations/VariationForm.php
+++ b/code/product/variations/VariationForm.php
@@ -104,7 +104,9 @@ class VariationForm extends AddProductForm {
 
 		$this->extend('updateVariationAddToCart', $form, $variation);
 
-		ShoppingCart_Controller::direct();
+		$request = $this->getRequest();
+		$this->extend('updateVariationFormResponse', $request, $response, $variation, $quantity, $form);
+		return $response ? $response : ShoppingCart_Controller::direct();
 	}
 
 	public function getBuyable($data = null) {


### PR DESCRIPTION
This PR doesn't add full ajax support but it adds extension hooks to make that happen. In the mean time, so that these features can be used safely in modules, I've separated the actual features into a couple modules. I felt the ajax module itself could be useful outside of the shop module so I think we should probably leave it separate. If you want to merge the shop-ajax module into shop core to keep from having two sets of pull requests in the future, I'm totally fine with that.
- https://github.com/markguinn/silverstripe-ajax
- https://github.com/markguinn/silverstripe-shop-ajax
