### PR TITLE
Update CheckoutStep_Address.php: function setbillingaddress

### DIFF
--- a/code/checkout/steps/CheckoutStep_Address.php
+++ b/code/checkout/steps/CheckoutStep_Address.php
@@ -78,7 +78,7 @@ class CheckoutStep_Address extends CheckoutStep{
 
 	public function setbillingaddress($data, $form) {
 		$this->billingconfig()->setData($form->getData());
-		return $this->owner->redirect($this->NextStepLink($step));
+		return $this->owner->redirect($this->NextStepLink());
 	}
 
 }


### PR DESCRIPTION
Remove $step from within $this->NextStepLink($step) as $step is not defined in the setbillingaddress function.  
This change seems to work well in the browser, however, testBillingAddress in SteppedCheckoutTest fails.
