### PR TITLE
Update CheckoutStep_PaymentMethod.php

### DIFF
--- a/code/checkout/steps/CheckoutStep_PaymentMethod.php
+++ b/code/checkout/steps/CheckoutStep_PaymentMethod.php
@@ -29,7 +29,7 @@ class CheckoutStep_PaymentMethod extends CheckoutStep{
 		$form->setActions(new FieldList(
 			FormAction::create("setpaymentmethod", "Continue")
 		));
-		$this->owner->extend('updateConfirmationForm', $form);
+		$this->owner->extend('updatePaymentMethodForm', $form);
 
 		return $form;
 	}


### PR DESCRIPTION
Make the extend name consistent with the form name.  There is already an extend name "updateConfirmationForm" in the ConfirmationForm function within the CheckoutStep_Summary class.  Thanks.
