### PR TITLE
Update SteppedCheckoutPage.ss

### DIFF
--- a/templates/Layout/SteppedCheckoutPage.ss
+++ b/templates/Layout/SteppedCheckoutPage.ss
@@ -120,9 +120,9 @@
 				<div class="accordion-group">
 					<div class="accordion-heading">
 						<% if IsPastStep(paymentmethod) %>
-							<h3><a class="accordion-toggle" title="choose payment method" href="$Link(paymentmethod)">Payment</a></h3>
+							<h3><a class="accordion-toggle" title="choose payment method" href="$Link(paymentmethod)">Payment Method</a></h3>
 						<% else %>
-							<h3 class="accordion-toggle">Payment</h3>
+							<h3 class="accordion-toggle">Payment Method</h3>
 						<% end_if %>
 					</div>
 					<% if IsFutureStep(paymentmethod) %>


### PR DESCRIPTION
Change the title from "Payment" to "Payment Method" to avoid confusion with the following summary step where the user clicks the button "Proceed to Payment".
