### PR TITLE
Updated OrderReceiptStyle.ss for Email CSS Resets

### DIFF
--- a/css/order.css
+++ b/css/order.css
@@ -3,6 +3,7 @@ h1.title {
     text-align: right;
     border-bottom: 1px solid #CDDDDD;
     text-transform: uppercase;
+    line-height: 1.5em;
 }
 
 .warningMessage {

--- a/templates/Includes/OrderReceiptStyle.ss
+++ b/templates/Includes/OrderReceiptStyle.ss
@@ -1,124 +1,50 @@
 <style>
-<!--
-/** Global resetting for Design **/
+	/** Global Resets for Email Design **/
+	/** Reference: https://github.com/seanpowell/Email-Boilerplate/blob/master/email.html **/
+	
 	html {
-		font-size:1em;
-		font-family:Verdana, Arial, sans-serif;
-	}
-	body {
-		font-size:12px;
-		padding:10px;
-		margin:0;
-	}
-	a img { border:0; }
-	
-	h1.title{
-		font-size:1.5em;
-		display:block;
-		text-align:right;
-		border-bottom:1px solid #CDDDDD;
-		text-transform:uppercase;
+		font-size: 1em;
+		font-family: Tahoma, Verdana, sans-serif;
 	}
 	
-	#Content {
-		text-align:left;
-		margin:auto;
+	body, table#container {
+		font-size: 12px;
+		line-height: 100% !important;
+		padding: 0;
+		margin: 0;
+		width: 100% !important;
+		height: 100%;
+		box-sizing: border-box;
+		-webkit-font-smoothing: antialiased;
+		-webkit-text-size-adjust: 100%;
+		-ms-text-size-adjust:100%;
 	}
+	
+	table td {border-collapse: collapse;}  /* Outlook 07 & 10 padding issue */
 
-	table#SenderTable{
-		width:100%;
-	}
-		table#SenderTable .sender,
-		table#SenderTable .meta{
-			width:50%;
-		}
-	
-	table#MetaTable{
-		margin-left:auto;
-	}
-		
-	table#MetaTable .label{
-		font-weight:bold;
-	}
-	
-	table.infotable{
-		border:1px solid #CDDDDD;
+	table {     /* Remove spacing around Outlook 07, 10 tables */
 		border-collapse:collapse;
-		width:100%;
-		border-top:1px solid #ccc;
-		border-bottom:1px solid #ccc;
-		background:#fff;
-		margin-top:10px;
+		mso-table-lspace:0pt;
+		mso-table-rspace:0pt;
 	}
-		.warningMessage {
-			margin: 4px 0 0 3px;
-			padding: 5px;
-			width: 92%;
-			color: #DC1313;
-			border: 4px solid #FF7373;
-			background: #FED0D0;
-		}		
-		table.infotable h3 {
-			color: #4EA3D7;
-			font-size: 15px;
-			font-weight: normal;
-			font-family: Tahoma, Verdana, sans-serif;
-		}
 
-		table.infotable tr.Total td {
-			font-weight:bold;
-			font-size:14px;
+	img {
+		outline:none;
+		text-decoration:none; 
+		-ms-interpolation-mode: bicubic;
+		display:block;
+	}
 
-			text-transform:uppercase;
-		}
-			table.infotable tr td,
-			table.infotable tr th {
-				padding:5px;
-				color: #333;
-				border:1px solid #CDDDDD;
-			}
-				table.infotable td {
-					font-size:12px;
-				}
-				table.infotable tr.summary {
-					font-weight: bold;
-				}
-				table.infotable td.ordersummary {
-					font-size:1em;
-					border-bottom:1px solid #ccc;
-				}
-				table.infotable th {
-					font-weight:bold;
-					font-size:12px;
-					color:#000;
-					background:#E7EFEF;
-				}
-				table.infotable tr td a {
-					color:#4EA3D7;
-					text-decoration:underline;
-				}
-					table.infotable tr td a:hover {
-						text-decoration:none;
-					}
-		table.infotable .modifierRow,
-		table.infotable .threeColHeader{
-			text-align:right;
-		}			
-		
-		table.infotable .right {
-			text-align:right;
-		}
-		table.infotable .center {
-			text-align:center;
-		}
-		table.infotable .left,
-		table.infotable th {
-			text-align:left;
-		}
-		
-		#ShippingTable td,
-		#ShippingTable th{
-			width:50%;
-		}
--->
+	a img { border: none; }
+	
+	table#container {
+		margin: auto;
+	}
+
+	/* Main left and right padding */
+	table#container > tr > td {
+            padding: 0 20px 0 20px;
+    }
+
+
 </style>

--- a/templates/email/Order_AdminNotificationEmail.ss
+++ b/templates/email/Order_AdminNotificationEmail.ss
@@ -6,25 +6,31 @@
 		<% include OrderReceiptStyle %>
 	</head>
 	<body>
-		<table id="Content" cellspacing="0" cellpadding="0" summary="Email Information">
-			<thead>
-				<tr>
-					<th scope="col" colspan="2">
-						<h1 class="title">$Subject</h1>
-					</th>
-				</tr>
-			</thead>
-			<tbody>
-				<% if $Order %>
-					<% loop $Order %>
-						<tr>
-							<td>
-								<% include Order %>
-							</td>
-						</tr>
-					<% end_loop %>
-				<% end_if %>
-			</tbody>
+		<table id="container" cellpadding="0" cellspacing="0" border="0" >
+			<tr>
+				<td>
+					<table id="Content" cellspacing="0" cellpadding="0" summary="Email Information">
+						<thead>
+							<tr>
+								<th scope="col" colspan="2">
+									<h1 class="title">$Subject</h1>
+								</th>
+							</tr>
+						</thead>
+						<tbody>
+							<% if $Order %>
+								<% loop $Order %>
+									<tr>
+										<td>
+											<% include Order %>
+										</td>
+									</tr>
+								<% end_loop %>
+							<% end_if %>
+						</tbody>
+					</table>
+				</td>
+			</tr>
 		</table>
 	</body>
 </html>

--- a/templates/email/Order_ConfirmationEmail.ss
+++ b/templates/email/Order_ConfirmationEmail.ss
@@ -6,30 +6,36 @@
 		<% include OrderReceiptStyle %>
 	</head>
 	<body>
-		<table id="Content" cellspacing="0" cellpadding="0" summary="Email Information">
-			<thead>
-				<tr>
-					<th scope="col" colspan="2">
-						<h1 class="title">$Subject</h1>
-					</th>
-				</tr>
-			</thead>
-			<tbody>
-				<tr>
-					<td scope="row" colspan="2" class="typography">
-						$PurchaseCompleteMessage
-					</td>
-				</tr>
-				<% if $Order %>
-				<% loop $Order %>
-					<tr>
-						<td>
-							<% include Order %>
-						</td>
-					</tr>
-				<% end_loop %>
-				<% end_if %>
-			</tbody>
+		<table id="container" cellpadding="0" cellspacing="0" border="0" >
+			<tr>
+				<td>
+					<table id="Content" cellspacing="0" cellpadding="0" summary="Email Information">
+						<thead>
+							<tr>
+								<th scope="col" colspan="2">
+									<h1 class="title">$Subject</h1>
+								</th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr>
+								<td scope="row" colspan="2" class="typography">
+									$PurchaseCompleteMessage
+								</td>
+							</tr>
+							<% if $Order %>
+							<% loop $Order %>
+								<tr>
+									<td>
+										<% include Order %>
+									</td>
+								</tr>
+							<% end_loop %>
+							<% end_if %>
+						</tbody>
+					</table>
+				</td>
+			</tr>
 		</table>
 	</body>
 </html>

--- a/templates/email/Order_ReceiptEmail.ss
+++ b/templates/email/Order_ReceiptEmail.ss
@@ -6,30 +6,36 @@
 		<% include OrderReceiptStyle %>
 	</head>
 	<body>
-		<table id="Content" cellspacing="0" cellpadding="0" summary="Email Information">
-			<thead>
-				<tr>
-					<th scope="col" colspan="2">
-						<h1 class="title">$Subject</h1>
-					</th>
-				</tr>
-			</thead>
-			<tbody>
-				<tr>
-					<td scope="row" colspan="2" class="typography">
-						$PurchaseCompleteMessage
-					</td>
-				</tr>
-				<% if $Order %>
-				<% loop $Order %>
-					<tr>
-						<td>
-							<% include Order %>
-						</td>
-					</tr>
-				<% end_loop %>
-				<% end_if %>
-			</tbody>
+		<table id="container" cellpadding="0" cellspacing="0" border="0" >
+			<tr>
+				<td>
+					<table id="Content" cellspacing="0" cellpadding="0" summary="Email Information">
+						<thead>
+							<tr>
+								<th scope="col" colspan="2">
+									<h1 class="title">$Subject</h1>
+								</th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr>
+								<td scope="row" colspan="2" class="typography">
+									$PurchaseCompleteMessage
+								</td>
+							</tr>
+							<% if $Order %>
+							<% loop $Order %>
+								<tr>
+									<td>
+										<% include Order %>
+									</td>
+								</tr>
+							<% end_loop %>
+							<% end_if %>
+						</tbody>
+					</table>
+				</td>
+			</tr>
 		</table>
 	</body>
 </html>

--- a/templates/email/Order_StatusEmail.ss
+++ b/templates/email/Order_StatusEmail.ss
@@ -93,35 +93,41 @@
 		</style>
 	</head>
 	<body>
-		<table id="Content" cellspacing="0" cellpadding="0" summary="Email Information">
-			<thead>
-				<tr>
-					<th scope="col" colspan="2">
-						<h1><% _t("HEADLINE","Shop Status Change") %></h1>
-					</th>
-				</tr>
-				<tr>
-					<td scope="col">
-						<h1 class="PageTitle">$Subject</h1>
-					</td>
-				</tr>
-			</thead>
-			<tbody>
-				<% if $Order %>
-				<% with $Order %>
-					<tr>
-						<td scope="row" colspan="2" class="typography">
-							<p><% sprintf(_t("STATUSCHANGE","Status changed to \"%s\" for Order #"),$Status) %>{$ID}</p>
-						</td>
-					</tr>
-				<% end_with %>
-				<% end_if %>
-				<tr>
-					<td scope="row" colspan="2" class="typography">
-						<p>$Note</p>
-					</td>
-				</tr>
-			</tbody>
+		<table id="container" cellpadding="0" cellspacing="0" border="0" >
+			<tr>
+				<td>
+					<table id="Content" cellspacing="0" cellpadding="0" summary="Email Information">
+						<thead>
+							<tr>
+								<th scope="col" colspan="2">
+									<h1><% _t("HEADLINE","Shop Status Change") %></h1>
+								</th>
+							</tr>
+							<tr>
+								<td scope="col">
+									<h1 class="PageTitle">$Subject</h1>
+								</td>
+							</tr>
+						</thead>
+						<tbody>
+							<% if $Order %>
+							<% with $Order %>
+								<tr>
+									<td scope="row" colspan="2" class="typography">
+										<p><% sprintf(_t("STATUSCHANGE","Status changed to \"%s\" for Order #"),$Status) %>{$ID}</p>
+									</td>
+								</tr>
+							<% end_with %>
+							<% end_if %>
+							<tr>
+								<td scope="row" colspan="2" class="typography">
+									<p>$Note</p>
+								</td>
+							</tr>
+						</tbody>
+					</table>
+				</td>
+			</tr>
 		</table>
 	</body>
 </html>


### PR DESCRIPTION
Uncommented the global resets in OrderReceiptStyle.ss and provided some base styles as recommended by seanpowell/Email-Boilerplate.   Also added a table#container wrapper to provide left/right padding in emails.  Thanks.