### PR TITLE
Fix `canPurchase` method.

### DIFF
--- a/code/exceptions/ShopBuyableException.php
+++ b/code/exceptions/ShopBuyableException.php
@@ -3,7 +3,13 @@
 /**
  * @package    shop
  * @subpackage exceptions
+ * @deprecated 2.0 This class will be removed in the next major version.
  */
 class ShopBuyableException extends Exception
 {
+    public function __construct($message, $code, Exception $previous)
+    {
+        Deprecation::notice('2.0', 'This class will be removed in the next major version.', Deprecation::SCOPE_CLASS);
+        parent::__construct($message, $code, $previous);
+    }
 }

--- a/code/product/variations/ProductVariation.php
+++ b/code/product/variations/ProductVariation.php
@@ -212,12 +212,10 @@ class ProductVariation extends DataObject implements Buyable
             $allowpurchase =
                 ($this->sellingPrice() > 0 || Product::config()->allow_zero_price) && $product->AllowPurchase;
         }
-        $extended = $this->extendedCan('canPurchase', $member, $quantity);
-        if ($allowpurchase && $extended !== null) {
-            $allowpurchase = $extended;
-        }
 
-        return $allowpurchase;
+        $permissions = $this->extend('canPurchase', $member, $quantity);
+        $permissions[] = $allowpurchase;
+        return min($permissions);
     }
 
     /*


### PR DESCRIPTION
Fixing issue #443, where `$quantity` won't be passed to the `canPurchase` method in extensions.
Deprecate `ShopBuyableException`.