### PR TITLE
Pass more data through to the payment processor if needed

### DIFF
--- a/code/checkout/PaymentForm.php
+++ b/code/checkout/PaymentForm.php
@@ -107,7 +107,7 @@ class PaymentForm extends CheckoutForm
         if ($components->first() instanceof CheckoutComponent_Namespaced) {
             foreach ($components as $component) {
                 if ($component->Proxy() instanceof OnsitePaymentCheckoutComponent) {
-                    $data = $component->unnamespaceData($data);
+                    $data = array_merge($data, $component->unnamespaceData($data));
                 }
             }
         }


### PR DESCRIPTION
Does anyone see a problem with this? It's helpful for the Braintree integration I'm working on because it means the payment gateway gets to see fields in the input that aren't prefixed with `OnsitePaymentCheckoutComponent_` - in this case `payment_method_nonce`.

The worry would be this gives a bit more surface for an attacker to say inject things like the amount (although that specific one is covered). The PurchaseService does explicitly set some things and I don't see any obvious attack vectors.