### PR TITLE
Use ShopAccountFormValidator to validate member Email Address changes…

### DIFF
--- a/code/checkout/components/MembershipCheckoutComponent.php
+++ b/code/checkout/components/MembershipCheckoutComponent.php
@@ -54,7 +54,7 @@ class MembershipCheckoutComponent extends CheckoutComponent
             return array();
         }
         return array(
-            Member::get_unique_identifier_field(),
+            Member::config()->unique_identifier_field,
             'Password',
         );
     }
@@ -90,7 +90,8 @@ class MembershipCheckoutComponent extends CheckoutComponent
                         'A member already exists with the {Field} {Identifier}',
                         '',
                         array('Field' => $fieldLabel, 'Identifier' => $idval)
-                    )
+                    ),
+                    $idfield
                 );
             }
             $passwordresult = $this->passwordvalidator->validate($data['Password'], $member);


### PR DESCRIPTION
… gracefully. 
This is a substitute for the changes proposed with: #446 

Minor improvement in MembershipCheckoutComponent: No longer use deprecated accessors and add the error message at the proper location in the form.