### PR TITLE
Requires email-helpers, uses StyleHtmlEmail (Emogrifier) by default

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -20,6 +20,8 @@ OrderProcessor:
 Injector:
   CheckoutComponentConfig:
     class: SinglePageCheckoutComponentConfig
+  ShopEmail:
+    class: StyledHtmlEmail
 
 LeftAndMain:
   extra_requirements_css:

--- a/code/account/OrderActionsForm.php
+++ b/code/account/OrderActionsForm.php
@@ -149,20 +149,11 @@ class OrderActionsForm extends Form
         ) {
             $this->order->Status = 'MemberCancelled';
             $this->order->write();
+
             if (self::config()->email_notification) {
-                $email = Email::create(
-                    Email::config()->admin_email,
-                    Email::config()->admin_email,
-                    _t(
-                        'ShopEmail.CancelSubject',
-                        'Order #{OrderNo} cancelled by member',
-                        '',
-                        array('OrderNo' => $this->order->Reference)
-                    ),
-                    $this->order->renderWith('Order')
-                );
-                $email->send();
+                OrderEmailNotifier::create($this->order)->sendCancelNotification();
             }
+
             $this->controller->sessionMessage(
                 _t("OrderForm.OrderCancelled", "Order sucessfully cancelled"),
                 'warning'

--- a/code/checkout/OrderEmailNotifier.php
+++ b/code/checkout/OrderEmailNotifier.php
@@ -45,7 +45,8 @@ class OrderEmailNotifier
         $checkoutpage = CheckoutPage::get()->first();
         $completemessage = $checkoutpage ? $checkoutpage->PurchaseComplete : '';
 
-        $email = Email::create();
+        /** @var Email $email */
+        $email = Injector::inst()->create('ShopEmail');
         $email->setTemplate($template);
         $email->setFrom($from);
         $email->setTo($to);
@@ -139,6 +140,26 @@ class OrderEmailNotifier
     }
 
     /**
+     * Sends an email to the admin that an order has been cancelled
+     */
+    public function sendCancelNotification()
+    {
+        $email = Injector::inst()->create(
+            'ShopEmail',
+            Email::config()->admin_email,
+            Email::config()->admin_email,
+            _t(
+                'ShopEmail.CancelSubject',
+                'Order #{OrderNo} cancelled by member',
+                '',
+                array('OrderNo' => $this->order->Reference)
+            ),
+            $this->order->renderWith('Order')
+        );
+        $email->send();
+    }
+
+    /**
      * Send a message to the client containing the latest
      * note of {@link OrderStatusLog} and the current status.
      *
@@ -165,7 +186,7 @@ class OrderEmailNotifier
         } else {
             $adminEmail = Email::config()->admin_email;
         }
-        $e = Email::create();
+        $e = Injector::inst()->create('ShopEmail');
         $e->setTemplate('Order_StatusEmail');
         $e->populateTemplate(
             array(

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
 		"burnbright/silverstripe-omnipay" : "~1.1||~2.0",
 		"icecaster/versioned-gridfield": "~1.0",
 		"burnbright/silverstripe-listsorter": "~2.0",
-		"burnbright/silverstripe-sqlquerylist": "~1.0"
+		"burnbright/silverstripe-sqlquerylist": "~1.0",
+        "markguinn/silverstripe-email-helpers": "~1.2.0"
 	},
 	"require-dev": {
 		"guzzle/plugin-mock": "~3.1",

--- a/templates/Includes/OrderReceiptStyle.ss
+++ b/templates/Includes/OrderReceiptStyle.ss
@@ -1,5 +1,4 @@
 <style>
-<!--
 /** Global resetting for Design **/
 	html {
 		font-size:1em;
@@ -11,7 +10,7 @@
 		margin:0;
 	}
 	a img { border:0; }
-	
+
 	h1.title{
 		font-size:1.5em;
 		display:block;
@@ -19,7 +18,7 @@
 		border-bottom:1px solid #CDDDDD;
 		text-transform:uppercase;
 	}
-	
+
 	#Content {
 		text-align:left;
 		margin:auto;
@@ -32,15 +31,15 @@
 		table#SenderTable .meta{
 			width:50%;
 		}
-	
+
 	table#MetaTable{
 		margin-left:auto;
 	}
-		
+
 	table#MetaTable .label{
 		font-weight:bold;
 	}
-	
+
 	table.infotable{
 		border:1px solid #CDDDDD;
 		border-collapse:collapse;
@@ -57,7 +56,7 @@
 			color: #DC1313;
 			border: 4px solid #FF7373;
 			background: #FED0D0;
-		}		
+		}
 		table.infotable h3 {
 			color: #4EA3D7;
 			font-size: 15px;
@@ -103,8 +102,8 @@
 		table.infotable .modifierRow,
 		table.infotable .threeColHeader{
 			text-align:right;
-		}			
-		
+		}
+
 		table.infotable .right {
 			text-align:right;
 		}
@@ -115,10 +114,9 @@
 		table.infotable th {
 			text-align:left;
 		}
-		
+
 		#ShippingTable td,
 		#ShippingTable th{
 			width:50%;
 		}
--->
 </style>


### PR DESCRIPTION
NOTE: The diff below has all of OrderReceiptStyle.ss as a change but all I did was take out the comment lines.

This implements a change we discussed in #441 and should work in tandem with it.