### PR TITLE
No longer use deprecated methods (snake_case) of the omnipay module

### DIFF
--- a/code/account/OrderActionsForm.php
+++ b/code/account/OrderActionsForm.php
@@ -31,10 +31,10 @@ class OrderActionsForm extends Form
         $actions = FieldList::create();
         //payment
         if (self::config()->allow_paying && $order->canPay()) {
-            $gateways = GatewayInfo::get_supported_gateways();
+            $gateways = GatewayInfo::getSupportedGateways();
             //remove manual gateways
             foreach ($gateways as $gateway => $gatewayname) {
-                if (GatewayInfo::is_manual($gateway)) {
+                if (GatewayInfo::isManual($gateway)) {
                     unset($gateways[$gateway]);
                 }
             }
@@ -106,7 +106,7 @@ class OrderActionsForm extends Form
             $data = $form->getData();
             $gateway = (!empty($data['PaymentMethod'])) ? $data['PaymentMethod'] : null;
 
-            if (!GatewayInfo::is_manual($gateway)) {
+            if (!GatewayInfo::isManual($gateway)) {
                 $processor = OrderProcessor::create($this->order);
                 $data['cancelUrl'] = $processor->getReturnUrl();
                 $response = $processor->makePayment($gateway, $data);

--- a/code/checkout/Checkout.php
+++ b/code/checkout/Checkout.php
@@ -110,7 +110,7 @@ class Checkout
      */
     public function getPaymentMethods()
     {
-        return GatewayInfo::get_supported_gateways();
+        return GatewayInfo::getSupportedGateways();
     }
 
     /**

--- a/code/checkout/CheckoutFieldFactory.php
+++ b/code/checkout/CheckoutFieldFactory.php
@@ -44,7 +44,7 @@ class CheckoutFieldFactory
     public function getMembershipFields()
     {
         $fields = $this->getContactFields();
-        $idfield = Member::get_unique_identifier_field();
+        $idfield = Member::config()->unique_identifier_field;
         if (!$fields->fieldByName($idfield)) {
             $fields->push(TextField::create($idfield, $idfield)); //TODO: scaffold the correct id field
         }
@@ -89,8 +89,8 @@ class CheckoutFieldFactory
         return OptionsetField::create(
             'PaymentMethod',
             _t('CheckoutField.PaymentType', "Payment Type"),
-            GatewayInfo::get_supported_gateways(),
-            array_keys(GatewayInfo::get_supported_gateways())
+            GatewayInfo::getSupportedGateways(),
+            array_keys(GatewayInfo::getSupportedGateways())
         );
     }
 

--- a/code/checkout/OrderProcessor.php
+++ b/code/checkout/OrderProcessor.php
@@ -77,7 +77,7 @@ class OrderProcessor
 
         // Process payment, get the result back
         $response = $service->purchase($this->getGatewayData($gatewaydata));
-        if (GatewayInfo::is_manual($gateway)) {
+        if (GatewayInfo::isManual($gateway)) {
             //don't complete the payment at this stage, if payment is manual
             $this->placeOrder();
         }
@@ -137,7 +137,7 @@ class OrderProcessor
      */
     public function createPayment($gateway)
     {
-        if (!GatewayInfo::is_supported($gateway)) {
+        if (!GatewayInfo::isSupported($gateway)) {
             $this->error(
                 _t(
                     "PaymentProcessor.InvalidGateway",

--- a/code/checkout/PaymentForm.php
+++ b/code/checkout/PaymentForm.php
@@ -53,8 +53,8 @@ class PaymentForm extends CheckoutForm
         $order = $this->config->getOrder();
         $gateway = Checkout::get($order)->getSelectedPaymentMethod(false);
         if (
-            GatewayInfo::is_offsite($gateway)
-            || GatewayInfo::is_manual($gateway)
+            GatewayInfo::isOffsite($gateway)
+            || GatewayInfo::isManual($gateway)
             || $this->config->getComponentByType('OnsitePaymentCheckoutComponent')
         ) {
             return $this->submitpayment($data, $form);

--- a/code/checkout/components/CheckoutComponentConfig.php
+++ b/code/checkout/components/CheckoutComponentConfig.php
@@ -222,7 +222,7 @@ class SinglePageCheckoutComponentConfig extends CheckoutComponentConfig
         if (Checkout::member_creation_enabled() && !Member::currentUserID()) {
             $this->addComponent(MembershipCheckoutComponent::create());
         }
-        if (count(GatewayInfo::get_supported_gateways()) > 1) {
+        if (count(GatewayInfo::getSupportedGateways()) > 1) {
             $this->addComponent(PaymentCheckoutComponent::create());
         }
         $this->addComponent(NotesCheckoutComponent::create());

--- a/code/checkout/components/OnsitePaymentCheckoutComponent.php
+++ b/code/checkout/components/OnsitePaymentCheckoutComponent.php
@@ -27,7 +27,7 @@ class OnsitePaymentCheckoutComponent extends CheckoutComponent
 
     public function getRequiredFields(Order $order)
     {
-        return GatewayInfo::required_fields(Checkout::get($order)->getSelectedPaymentMethod());
+        return GatewayInfo::requiredFields(Checkout::get($order)->getSelectedPaymentMethod());
     }
 
     public function validateData(Order $order, array $data)

--- a/code/checkout/components/PaymentCheckoutComponent.php
+++ b/code/checkout/components/PaymentCheckoutComponent.php
@@ -5,7 +5,7 @@ class PaymentCheckoutComponent extends CheckoutComponent
     public function getFormFields(Order $order)
     {
         $fields = FieldList::create();
-        $gateways = GatewayInfo::get_supported_gateways();
+        $gateways = GatewayInfo::getSupportedGateways();
         if (count($gateways) > 1) {
             $fields->push(
                 OptionsetField::create(
@@ -27,7 +27,7 @@ class PaymentCheckoutComponent extends CheckoutComponent
 
     public function getRequiredFields(Order $order)
     {
-        if (count(GatewayInfo::get_supported_gateways()) > 1) {
+        if (count(GatewayInfo::getSupportedGateways()) > 1) {
             return array();
         }
 
@@ -44,7 +44,7 @@ class PaymentCheckoutComponent extends CheckoutComponent
             );
             throw new ValidationException($result);
         }
-        $methods = GatewayInfo::get_supported_gateways();
+        $methods = GatewayInfo::getSupportedGateways();
         if (!isset($methods[$data['PaymentMethod']])) {
             $result->error(_t('PaymentCheckoutComponent.UnsupportedGateway', "Gateway not supported"), "PaymentMethod");
             throw new ValidationException($result);

--- a/code/checkout/steps/CheckoutStep_PaymentMethod.php
+++ b/code/checkout/steps/CheckoutStep_PaymentMethod.php
@@ -17,7 +17,7 @@ class CheckoutStep_PaymentMethod extends CheckoutStep
 
     public function paymentmethod()
     {
-        $gateways = GatewayInfo::get_supported_gateways();
+        $gateways = GatewayInfo::getSupportedGateways();
         if (count($gateways) == 1) {
             return $this->owner->redirect($this->NextStepLink());
         }

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "php": ">=5.4",
 		"silverstripe/cms": "~3.1",
 		"silverstripe/framework": "~3.1",
-		"burnbright/silverstripe-omnipay" : "~1.1 || ~2.0",
+		"burnbright/silverstripe-omnipay" : "2.0.x-dev",
 		"icecaster/versioned-gridfield": "~1.0",
 		"burnbright/silverstripe-listsorter": "~2.0",
 		"burnbright/silverstripe-sqlquerylist": "~1.0",

--- a/tests/model/ShopPaymentTest.php
+++ b/tests/model/ShopPaymentTest.php
@@ -28,8 +28,8 @@ class ShopPaymentTest extends FunctionalTest
             'PaymentExpress_PxPost' //onsite
         );
 
-        PaymentService::set_http_client($this->getHttpClient());
-        PaymentService::set_http_request($this->getHttpRequest());
+        PaymentService::setHttpClient($this->getHttpClient());
+        PaymentService::setHttpRequest($this->getHttpRequest());
 
         //publish products
         $this->objFromFixture("Product", "socks")->publish('Stage', 'Live');


### PR DESCRIPTION
See https://github.com/burnbright/silverstripe-omnipay/pull/104.
Also fix deprecated `Member::get_unique_identifier_field()` usage.