### PR TITLE
Added stage and live both to the versioning

### DIFF
--- a/code/product/variations/ProductVariation.php
+++ b/code/product/variations/ProductVariation.php
@@ -38,11 +38,11 @@ class ProductVariation extends DataObject implements Buyable
     );
 
     private static $versioning        = array(
-        'Live',
+        "Stage",  "Live"
     );
 
     private static $extensions        = array(
-        "Versioned('Live')",
+        "Versioned('Stage', Live')",
     );
 
     private static $summary_fields    = array(


### PR DESCRIPTION
without these configs it doesnt create a ProductVariation_Live table and results in errors.

"[User Error] Uncaught SS_DatabaseException: Couldn't run query: SELECT "Version" FROM "ProductVariation_Live" WHERE "ID" = ? Table 'getmagicbullet.productvariation_live' doesn't exist"