### PR TITLE
Updated shop to use the 2.0 release-candidate of the omnipay-module.

### DIFF
--- a/code/checkout/Checkout.php
+++ b/code/checkout/Checkout.php
@@ -1,5 +1,7 @@
 <?php
 
+use SilverStripe\Omnipay\GatewayInfo;
+
 /**
  * Helper class for getting an order throught the checkout process
  */

--- a/code/checkout/CheckoutFieldFactory.php
+++ b/code/checkout/CheckoutFieldFactory.php
@@ -1,5 +1,7 @@
 <?php
 
+use SilverStripe\Omnipay\GatewayInfo;
+
 /**
  * Factory for generating checkout fields
  *

--- a/code/checkout/PaymentForm.php
+++ b/code/checkout/PaymentForm.php
@@ -1,5 +1,7 @@
 <?php
 
+use SilverStripe\Omnipay\GatewayInfo;
+
 class PaymentForm extends CheckoutForm
 {
     /**
@@ -73,10 +75,9 @@ class PaymentForm extends CheckoutForm
     public function submitpayment($data, $form)
     {
         $data = $form->getData();
-        if ($this->getSuccessLink()) {
-            $data['returnUrl'] = $this->getSuccessLink();
-        }
-        $data['cancelUrl'] = $this->getFailureLink() ? $this->getFailureLink() : $this->controller->Link();
+
+        $cancelUrl = $this->getFailureLink() ? $this->getFailureLink() : $this->controller->Link();
+
         $order = $this->config->getOrder();
 
         // final recalculation, before making payment
@@ -98,7 +99,7 @@ class PaymentForm extends CheckoutForm
                 $form->sessionMessage($this->orderProcessor->getError());
                 return $this->controller->redirectBack();
             }
-            $data['cancelUrl'] = $this->orderProcessor->getReturnUrl();
+            $cancelUrl = $this->orderProcessor->getReturnUrl();
         }
 
         // if we got here from checkoutSubmit and there's a namespaced OnsitePaymentCheckoutComponent
@@ -115,21 +116,16 @@ class PaymentForm extends CheckoutForm
         // This is where the payment is actually attempted
         $paymentResponse = $this->orderProcessor->makePayment(
             Checkout::get($order)->getSelectedPaymentMethod(false),
-            $data
+            $data,
+            $this->getSuccessLink(),
+            $cancelUrl
         );
 
         $response = null;
-        if ($paymentResponse) {
-            if ($this->controller->hasMethod('processPaymentResponse')) {
-                $response = $this->controller->processPaymentResponse($paymentResponse, $form);
-            } else {
-                if ($paymentResponse->isRedirect() || $paymentResponse->isSuccessful()) {
-                    $response = $paymentResponse->redirect();
-                } else {
-                    $form->sessionMessage($paymentResponse->getMessage(), 'bad');
-                    $response = $this->controller->redirectBack();
-                }
-            }
+        if ($this->controller->hasMethod('processPaymentResponse')) {
+            $response = $this->controller->processPaymentResponse($paymentResponse, $form);
+        } else if ($paymentResponse && !$paymentResponse->isError()) {
+            $response = $paymentResponse->redirectOrRespond();
         } else {
             $form->sessionMessage($this->orderProcessor->getError(), 'bad');
             $response = $this->controller->redirectBack();

--- a/code/checkout/components/CheckoutComponentConfig.php
+++ b/code/checkout/components/CheckoutComponentConfig.php
@@ -1,5 +1,7 @@
 <?php
 
+use SilverStripe\Omnipay\GatewayInfo;
+
 /**
  * @package shop
  */

--- a/code/checkout/components/OnsitePaymentCheckoutComponent.php
+++ b/code/checkout/components/OnsitePaymentCheckoutComponent.php
@@ -1,6 +1,7 @@
 <?php
 
 use Omnipay\Common\Helper;
+use SilverStripe\Omnipay\GatewayInfo;
 
 /**
  *

--- a/code/checkout/components/PaymentCheckoutComponent.php
+++ b/code/checkout/components/PaymentCheckoutComponent.php
@@ -1,5 +1,7 @@
 <?php
 
+use SilverStripe\Omnipay\GatewayInfo;
+
 class PaymentCheckoutComponent extends CheckoutComponent
 {
     public function getFormFields(Order $order)

--- a/code/checkout/steps/CheckoutStep_PaymentMethod.php
+++ b/code/checkout/steps/CheckoutStep_PaymentMethod.php
@@ -1,5 +1,7 @@
 <?php
 
+use SilverStripe\Omnipay\GatewayInfo;
+
 class CheckoutStep_PaymentMethod extends CheckoutStep
 {
     private static $allowed_actions = array(

--- a/code/model/ShopPayment.php
+++ b/code/model/ShopPayment.php
@@ -1,5 +1,7 @@
 <?php
 
+use SilverStripe\Omnipay\Service\ServiceResponse;
+
 /**
  * Customisations to {@link Payment} specifically for the shop module.
  *
@@ -11,11 +13,34 @@ class ShopPayment extends DataExtension
         'Order' => 'Order',
     );
 
-    public function onCaptured($response)
+    public function onAwaitingAuthorized(ServiceResponse $response)
+    {
+        $this->placeOrder();
+    }
+
+    public function onAwaitingCaptured(ServiceResponse $response)
+    {
+        $this->placeOrder();
+    }
+
+    public function onAuthorized(ServiceResponse $response)
+    {
+        $this->placeOrder();
+    }
+
+    public function onCaptured(ServiceResponse $response)
     {
         $order = $this->owner->Order();
         if ($order->exists()) {
             OrderProcessor::create($order)->completePayment();
+        }
+    }
+
+    protected function placeOrder()
+    {
+        $order = $this->owner->Order();
+        if ($order->exists()) {
+            OrderProcessor::create($order)->placeOrder();
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "php": ">=5.4",
 		"silverstripe/cms": "~3.1",
 		"silverstripe/framework": "~3.1",
-		"burnbright/silverstripe-omnipay" : "2.0.x-dev",
+		"silverstripe/silverstripe-omnipay" : "2.0.x-dev",
 		"icecaster/versioned-gridfield": "~1.0",
 		"burnbright/silverstripe-listsorter": "~2.0",
 		"burnbright/silverstripe-sqlquerylist": "~1.0",

--- a/tests/model/ShopPaymentTest.php
+++ b/tests/model/ShopPaymentTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use SilverStripe\Omnipay\Service\PaymentService;
+
 class ShopPaymentTest extends FunctionalTest
 {
     protected static $fixture_file  = array(
@@ -78,14 +80,16 @@ class ShopPaymentTest extends FunctionalTest
         $this->setMockHttpResponse('paymentexpress/tests/Mock/PxPayCompletePurchaseSuccess.txt');
         $this->getHttpRequest()->query->replace(array('result' => 'abc123'));
         $identifier = $response->getPayment()->Identifier;
+
+        //bring back client session
+        $this->mainSession = $oldsession;
+        // complete the order
         $response = $this->get("paymentendpoint/$identifier/complete");
+
         //reload cart as new order
         $order = Order::get()->byId($cart->ID);
         $this->assertFalse($order->isCart(), "order is no longer in cart");
         $this->assertTrue($order->isPaid(), "order is paid");
-        //bring back client session
-        $this->mainSession = $oldsession;
-        $response = $this->get("paymentendpoint/$identifier/complete");
         $this->assertNull(Session::get("shoppingcartid"), "cart session id should be removed");
         $this->assertNotEquals(404, $response->getStatusCode(), "We shouldn't get page not found");
 


### PR DESCRIPTION
Main Changes are:
 - Make use of the new namespaces
 - Explicitly set the success and cancel URLs (passing them via form-data is no longer allowed)
 - Calculate order-total either with- or without authorized payments (when a payment is authorized, user shouldn't see the "Pay outstanding" button on his order)