### PR TITLE
Ensure that OrderID is also being set on partial payments

### DIFF
--- a/_config/extensions.yml
+++ b/_config/extensions.yml
@@ -35,3 +35,6 @@ Payment:
 Order:
   extensions:
     - Payable
+SilverStripe\Omnipay\Service\PaymentService:
+  extensions:
+    - ShopPaymentService

--- a/code/model/ShopPaymentService.php
+++ b/code/model/ShopPaymentService.php
@@ -1,0 +1,11 @@
+<?php
+
+/**
+ */
+class ShopPaymentService extends Extension
+{
+    public function updatePartialPayment($newPayment, $originalPayment)
+    {
+        $newPayment->OrderID = $originalPayment->OrderID;
+    }
+}


### PR DESCRIPTION
New feature in the silverstripe-omnipay 2.0 module.