### PR TITLE
Fixed order of constructor arguments.

### DIFF
--- a/code/product/AddProductForm.php
+++ b/code/product/AddProductForm.php
@@ -105,7 +105,7 @@ class AddProductForm extends Form
             $fields->push(DropdownField::create('Quantity', _t('AddProductForm.Quantity', 'Quantity'), $values, 1));
         } else {
             $fields->push(
-                NumericField::create(_t('AddProductForm.Quantity', 'Quantity'), 'Quantity', 1)
+                NumericField::create('Quantity', _t('AddProductForm.Quantity', 'Quantity'), 1)
                     ->setAttribute('type', 'number')
                     ->setAttribute('min', '0')
             );


### PR DESCRIPTION
The numeric field in `AddProductForm` was using the translation as field name.