### PR TITLE
Update order upon setting Status to Paid.

### DIFF
--- a/code/checkout/OrderEmailNotifier.php
+++ b/code/checkout/OrderEmailNotifier.php
@@ -135,8 +135,6 @@ class OrderEmailNotifier
             $subject,
             self::config()->bcc_receipt_to_admin
         );
-        $this->order->ReceiptSent = SS_Datetime::now()->Rfc2822();
-        $this->order->write();
     }
 
     /**

--- a/code/checkout/OrderProcessor.php
+++ b/code/checkout/OrderProcessor.php
@@ -197,7 +197,7 @@ class OrderProcessor
      */
     public function completePayment()
     {
-        if (!$this->order->Paid) {
+        if (!$this->order->IsPaid()) {
             // recalculate order to be sure we have the correct total
             $this->order->calculate();
 
@@ -219,16 +219,7 @@ class OrderProcessor
             ) {
                 //set order as paid
                 $this->order->Status = 'Paid';
-                $this->order->Paid = SS_Datetime::now()->Rfc2822();
                 $this->order->write();
-                foreach ($this->order->Items() as $item) {
-                    $item->onPayment();
-                }
-                //all payment is settled
-                $this->order->extend('onPaid');
-            }
-            if (!$this->order->ReceiptSent) {
-                $this->notifier->sendReceipt();
             }
         }
     }


### PR DESCRIPTION
Set order paid date and send recipe when the order-status changes to `Paid`. This is needed to properly mark an order as Paid in cases where Payments don't reach the total amount (eg. an authorized payment that was only partially captured)
Modified OrderProcessor to just set order status to `Paid` if order is fully paid.
Added Unit-Tests.
Removed redundant write in `OrderEmailNotifier`.
Fix for #496 