### PR TITLE
Use a TextField instead of NumericField in `CartEditField` …

### DIFF
--- a/code/cart/CartEditField.php
+++ b/code/cart/CartEditField.php
@@ -101,11 +101,12 @@ class CartEditField extends FormField
                 continue;
             }
             $name = $this->name . "[$item->ID]";
-            $quantity = NumericField::create(
+            $quantity = TextField::create(
                 $name . "[Quantity]",
                 "Quantity",
                 $item->Quantity
             )
+                ->addExtraClass('numeric')
                 ->setAttribute('type', 'number')
                 ->setAttribute('min', '0');
 

--- a/code/cart/CartForm.php
+++ b/code/cart/CartForm.php
@@ -37,6 +37,8 @@ class CartForm extends Form
             ShopTools::install_locale($order->Locale);
         }
 
+        $numericConverter = NumericField::create('_temp');
+
         $messages = array();
         if (isset($data['Items']) && is_array($data['Items'])) {
             foreach ($data['Items'] as $itemid => $fields) {
@@ -52,7 +54,8 @@ class CartForm extends Form
                 }
                 //update quantities
                 if (isset($fields['Quantity']) && $quantity = Convert::raw2sql($fields['Quantity'])) {
-                    $item->Quantity = $quantity;
+                    $numericConverter->setValue($quantity);
+                    $item->Quantity = $numericConverter->dataValue();
                 }
                 //update variations
                 if (isset($fields['ProductVariationID']) && $id = Convert::raw2sql($fields['ProductVariationID'])) {


### PR DESCRIPTION
…as NumericField is incompatible with the HTML5 numeric field (due to date formatting).

Improve CartForm by running incoming quantity values through a numeric-field (in case formatted numbers get sent as parameters)
Fixes #386 