### PR TITLE
When adding a product with variations to cart, make sure that the …

### DIFF
--- a/code/product/variations/ProductVariation.php
+++ b/code/product/variations/ProductVariation.php
@@ -277,9 +277,6 @@ class ProductVariation extends DataObject implements Buyable
     public function sellingPrice()
     {
         $price = $this->Price;
-        if ($price == 0 && ($parentProduct = $this->Product())) {
-            $price = $parentProduct->sellingPrice();
-        }
         $this->extend("updateSellingPrice", $price);
 
         //prevent negative values

--- a/code/product/variations/VariationForm.php
+++ b/code/product/variations/VariationForm.php
@@ -37,13 +37,17 @@ class VariationForm extends AddProductForm
 
         if (self::$include_json) {
             $vararray = array();
-            
+
             $query = $query2 = new SQLQuery();
-            
+
             $query->setSelect('ID')
                 ->setFrom('ProductVariation')
-                ->setWhere(array('ProductID' => $product->ID));
-                
+                ->addWhere(array('ProductID' => $product->ID));
+
+            if (!Product::config()->allow_zero_price) {
+                $query->addWhere('"Price" > 0');
+            }
+
             foreach ($query->execute()->column('ID') as $variationID) {
                 $query2->setSelect('ProductAttributeValueID')
                     ->setFrom('ProductVariation_AttributeValues')
@@ -100,7 +104,7 @@ class VariationForm extends AddProductForm
 
                 try {
                     $success = $variation->canPurchase(null, $data['Quantity']);
-                } catch (ShopBuyableException $e) {
+                } catch (Exception $e) {
                     $message = get_class($e);
                     // added hook to update message
                     $this->extend('updateVariationAddToCartMessage', $e, $message, $variation);
@@ -142,7 +146,7 @@ class VariationForm extends AddProductForm
     public function getBuyable($data = null)
     {
         if (isset($data['ProductAttributes'])
-            && $variation = $this->Controller()->getVariationByAttributes($data['ProductAttributes'])
+            && $variation = $this->getController()->getVariationByAttributes($data['ProductAttributes'])
         ) {
             return $variation;
         }

--- a/tests/cart/ShoppingCartTest.php
+++ b/tests/cart/ShoppingCartTest.php
@@ -76,4 +76,22 @@ class ShoppingCartTest extends SapphireTest
 
         $this->assertEquals($order->ID, ShoppingCart::curr()->ID, "if singleton order ids will match");
     }
+
+    public function testAddProductWithVariations()
+    {
+        $this->loadFixture('silvershop/tests/fixtures/variations.yml');
+        $ball = $this->objFromFixture('Product', 'ball');
+        $redlarge = $this->objFromFixture('ProductVariation', 'redlarge');
+        // setting price of variation to zero, so it can't be added to cart.
+        $redlarge->Price = 0;
+        $redlarge->write();
+
+        $ball->BasePrice = 0;
+        $ball->write();
+
+        $item = $this->cart->add($ball);
+        $this->assertNotNull($item, "Product with variations can be added to cart");
+        $this->assertInstanceOf('ProductVariation_OrderItem', $item, 'A variation should be added to cart.');
+        $this->assertEquals(20, $item->Buyable()->Price, 'The buyable variation was added');
+    }
 }

--- a/tests/fixtures/variations.yml
+++ b/tests/fixtures/variations.yml
@@ -50,6 +50,7 @@ Product:
 ProductVariation:
     redlarge:
         Product: =>Product.ball
+        Price: 22.00
         AttributeValues: =>ProductAttributeValue.size_large,=>ProductAttributeValue.color_red
     redsmall:
         Product: =>Product.ball


### PR DESCRIPTION
…first valid variation is added instead.

Ensure that variations with no price are not selectable, unless the `Product.allow_zero_price` setting is set to `true`.
Updated unit-tests.
Minor formatting fixes and a small deprecation API fix.

Change in behavior/API: Variations no longer inherit price from Product. Didn't make sense anyways, since the product price can no longer be modified once a variation was added.

Fixes #231 