### PR TITLE
Optional Shipping

### DIFF
--- a/code/checkout/components/CheckoutComponentConfig.php
+++ b/code/checkout/components/CheckoutComponentConfig.php
@@ -217,7 +217,9 @@ class SinglePageCheckoutComponentConfig extends CheckoutComponentConfig
     {
         parent::__construct($order);
         $this->addComponent(CustomerDetailsCheckoutComponent::create());
-        $this->addComponent(ShippingAddressCheckoutComponent::create());
+         if(!CheckoutConfig::config()->ShippingOptional){ 
+			$this->addComponent(ShippingAddressCheckoutComponent::create());
+		}
         $this->addComponent(BillingAddressCheckoutComponent::create());
         if (Checkout::member_creation_enabled() && !Member::currentUserID()) {
             $this->addComponent(MembershipCheckoutComponent::create());


### PR DESCRIPTION
I've been working with subscription products and so don't need the
shipping address form and the validation that comes with it.

I've added this switch in the Checkout Config to turn the shipping
address off:
CheckoutConfig:
ShippingOptional: true