### PR TITLE
Revert commits that re-added the ShopBuyableException.

### DIFF
--- a/code/ShopBuyableException.php
+++ b/code/ShopBuyableException.php
@@ -1,9 +1,0 @@
-<?php
-
-/**
- * @package silvershop
- * @subpackage exceptions
- */
-class ShopBuyableException extends Exception {
-    
-}

--- a/code/cart/CartForm.php
+++ b/code/cart/CartForm.php
@@ -43,51 +43,31 @@ class CartForm extends Form
         if (isset($data['Items']) && is_array($data['Items'])) {
             foreach ($data['Items'] as $itemid => $fields) {
                 $item = $items->byID($itemid);
-
                 if (!$item) {
                     continue;
                 }
-
-
-                // delete lines
+                //delete lines
                 if (isset($fields['Remove']) || (isset($fields['Quantity']) && (int)$fields['Quantity'] <= 0)) {
-
-                    try {
-                        ShoppingCart::singleton()->remove($item->Buyable());
-
-                        $removecount++;
-                    } catch(ShopBuyableException $e) {
-                         $form->sessionMessage($e->getMessage(), "bad");
-
-                         break;
-                    }
-
+                    $items->remove($item);
+                    $removecount++;
                     continue;
                 }
-
-                // update quantities
+                //update quantities
                 if (isset($fields['Quantity']) && $quantity = Convert::raw2sql($fields['Quantity'])) {
                     $numericConverter->setValue($quantity);
-
-                    try {
-                        ShoppingCart::singleton()
-                            ->setQuantity($item->Buyable(), $numericConverter->dataValue());
-                    } catch(ShopBuyableException $e) {
-                         $form->sessionMessage($e->getMessage(), "bad");
-
-                         break;
-                    }
+                    $item->Quantity = $numericConverter->dataValue();
                 }
-
-                // update variations
+                //update variations
                 if (isset($fields['ProductVariationID']) && $id = Convert::raw2sql($fields['ProductVariationID'])) {
                     if ($item->ProductVariationID != $id) {
                         $item->ProductVariationID = $id;
-                        $item->write();
                     }
                 }
-
+                //TODO: make updates through ShoppingCart class
+                //TODO: combine with items that now match exactly
+                //TODO: validate changes
                 if ($item->isChanged()) {
+                    $item->write();
                     $updatecount++;
                 }
             }

--- a/code/product/AddProductForm.php
+++ b/code/product/AddProductForm.php
@@ -65,15 +65,9 @@ class AddProductForm extends Form
                 array_intersect_key($data, array_combine($this->saveablefields, $this->saveablefields))
             ) : $data;
             $quantity = isset($data['Quantity']) ? (int)$data['Quantity'] : 1;
-
-            try {
-                $cart->add($buyable, $quantity, $saveabledata);
-
-                if (!ShoppingCart_Controller::config()->direct_to_cart_page) {
-                    $form->SessionMessage($cart->getMessage(), $cart->getMessageType());
-                }
-            } catch(ShopBuyableException $e) {
-                $form->sessionMessage($e->getMessage(), 'bad');
+            $cart->add($buyable, $quantity, $saveabledata);
+            if (!ShoppingCart_Controller::config()->direct_to_cart_page) {
+                $form->SessionMessage($cart->getMessage(), $cart->getMessageType());
             }
 
             $this->extend('updateAddToCart', $form, $buyable);

--- a/code/product/variations/ProductVariationsExtension.php
+++ b/code/product/variations/ProductVariationsExtension.php
@@ -3,7 +3,7 @@
 /**
  * Adds extra fields and relationships to Products for variations support.
  *
- * @package    silvershop
+ * @package    shop
  * @subpackage variations
  */
 class ProductVariationsExtension extends DataExtension

--- a/code/product/variations/VariationForm.php
+++ b/code/product/variations/VariationForm.php
@@ -121,21 +121,16 @@ class VariationForm extends AddProductForm
                 return json_encode($ret);
             }
 
-            try {
-                if ($cart->add($variation, $quantity)) {
-                    $form->sessionMessage(
-                        _t('ShoppingCart.ItemAdded', "Item has been added successfully."),
-                        "good"
-                    );
-                } else {
-                    $form->sessionMessage($cart->getMessage(), $cart->getMessageType());
-                }
-            } catch(ShopBuyableException $e) {
-                $form->sessionMessage($e->getMessage(), 'bad');
+            if ($cart->add($variation, $quantity)) {
+                $form->sessionMessage(
+                    _t('ShoppingCart.ItemAdded', "Item has been added successfully."),
+                    "good"
+                );
+            } else {
+                $form->sessionMessage($cart->getMessage(), $cart->getMessageType());
             }
         } else {
             $variation = null;
-
             $form->sessionMessage(
                 _t('VariationForm.VariationNotAvailable', "That variation is not available, sorry."),
                 "bad"


### PR DESCRIPTION
Opening this up for discussion for the core-team (@markguinn, @wilr, @anselmdk), or any interested party. 

We have deprecated `ShopBuyableException` and removed it with 2.0. Some of the reasoning can be found in this issue: #443

The gist of it:

- Throwing an Exception from `canPurchase` seemed like a non-intuitive architecture, since the method already tells us whether or not a product can be purchased.
- The only reason the Exception was used there, was to pass a message to the outside.

Since `2.0` was our only chance to clean up API (before 3.0), I'd rather keep the exception removed and look for a short-term and long-term solution to the problem.

Proposed short-term fix:

 - Remove exception throwing from the [silvershop-stock](https://github.com/silvershop/silvershop-stock) module, so that it's compatible with core 2.0
 - Leave it up to the developer to improve the UX where neccessary (eg. limiting the amount of products that can be added to cart) without relying on exceptions

Proposed long-term fix:

There are several solutions for a long-term solution (most of this could be done within the 2.x release I think). I guess we should open a new issue for this and discuss it there. Some ideas:

 - Extend the API of `canPurchase` to pass in some sort of container for messages (reasons why product could not be added). Every extension can then append messages to the container, which can be displayed to the user.
 - Improve UI components, such as the "Add to cart" button or quantity fields so that they can be limited to max-amounts or can be disabled… with the goal to prevent running into invalid situations in the first place

Thanks for reading.
