### PR TITLE
Wrap all order extension hooks in try/catch blocks.

### DIFF
--- a/code/product/variations/ProductVariationsExtension.php
+++ b/code/product/variations/ProductVariationsExtension.php
@@ -3,7 +3,7 @@
 /**
  * Adds extra fields and relationships to Products for variations support.
  *
- * @package    shop
+ * @package    silvershop
  * @subpackage variations
  */
 class ProductVariationsExtension extends DataExtension

--- a/tests/cart/ShoppingCartTest.php
+++ b/tests/cart/ShoppingCartTest.php
@@ -6,17 +6,14 @@ class ShoppingCartTest extends SapphireTest
     public static $disable_theme  = true;
     public static $use_draft_site = false;
 
-    public function setUpOnce()
-    {
-        parent::setUpOnce();
-        // clear session
-        ShoppingCart::singleton()->clear();
-    }
-
     public function setUp()
     {
         parent::setUp();
         ShopTest::setConfiguration(); //reset config
+        Config::inst()->update('Order', 'extensions', ['ShoppingCartTest_TestShoppingCartHooksExtension']);
+
+        ShoppingCart::singleton()->clear();
+        ShoppingCartTest_TestShoppingCartHooksExtension::reset();
         $this->cart = ShoppingCart::singleton();
         $this->product = $this->objFromFixture('Product', 'mp3player');
         $this->product->publish('Stage', 'Live');
@@ -25,7 +22,17 @@ class ShoppingCartTest extends SapphireTest
     public function testAddToCart()
     {
         $this->assertTrue((boolean)$this->cart->add($this->product), "add one item");
+        $this->assertEquals(
+            ['onStartOrder', 'beforeAdd', 'afterAdd'],
+            ShoppingCartTest_TestShoppingCartHooksExtension::$stack
+        );
+
         $this->assertTrue((boolean)$this->cart->add($this->product), "add another item");
+        $this->assertEquals(
+            ['onStartOrder', 'beforeAdd', 'afterAdd', 'beforeAdd', 'afterAdd'],
+            ShoppingCartTest_TestShoppingCartHooksExtension::$stack
+        );
+
         $item = $this->cart->get($this->product);
         $this->assertEquals($item->Quantity, 2, "quantity is 2");
     }
@@ -33,7 +40,16 @@ class ShoppingCartTest extends SapphireTest
     public function testRemoveFromCart()
     {
         $this->assertTrue((boolean)$this->cart->add($this->product), "add item");
+        $this->assertEquals(
+            ['onStartOrder', 'beforeAdd', 'afterAdd'],
+            ShoppingCartTest_TestShoppingCartHooksExtension::$stack
+        );
+
         $this->assertTrue($this->cart->remove($this->product), "item was removed");
+        $this->assertEquals(
+            ['onStartOrder', 'beforeAdd', 'afterAdd', 'beforeRemove', 'afterRemove'],
+            ShoppingCartTest_TestShoppingCartHooksExtension::$stack
+        );
         $item = $this->cart->get($this->product);
         $this->assertFalse($item, "item not in cart");
         $this->assertFalse($this->cart->remove($this->product), "try remove non-existent item");
@@ -42,8 +58,15 @@ class ShoppingCartTest extends SapphireTest
     public function testSetQuantity()
     {
         $this->assertTrue((boolean)$this->cart->setQuantity($this->product, 25), "quantity set");
+
+        $this->assertEquals(
+            ['onStartOrder', 'beforeSetQuantity', 'afterSetQuantity'],
+            ShoppingCartTest_TestShoppingCartHooksExtension::$stack
+        );
+
         $item = $this->cart->get($this->product);
         $this->assertEquals($item->Quantity, 25, "quantity is 25");
+
     }
 
     public function testClear()
@@ -63,8 +86,20 @@ class ShoppingCartTest extends SapphireTest
         $ball2 = $this->objFromFixture('ProductVariation', 'redsmall');
 
         $this->assertTrue((boolean)$this->cart->add($ball1), "add one item");
+
+        $this->assertEquals(
+            ['onStartOrder', 'beforeAdd', 'afterAdd'],
+            ShoppingCartTest_TestShoppingCartHooksExtension::$stack
+        );
+
         $this->assertTrue((boolean)$this->cart->add($ball2), "add another item");
         $this->assertTrue($this->cart->remove($ball1), "remove first item");
+
+        $this->assertEquals(
+            ['onStartOrder', 'beforeAdd', 'afterAdd', 'beforeAdd', 'afterAdd', 'beforeRemove', 'afterRemove'],
+            ShoppingCartTest_TestShoppingCartHooksExtension::$stack
+        );
+
         $this->assertFalse($this->cart->get($ball1), "first item not in cart");
         $this->assertNotNull($this->cart->get($ball1), "second item is in cart");
     }
@@ -94,4 +129,91 @@ class ShoppingCartTest extends SapphireTest
         $this->assertInstanceOf('ProductVariation_OrderItem', $item, 'A variation should be added to cart.');
         $this->assertEquals(20, $item->Buyable()->Price, 'The buyable variation was added');
     }
+
+    public function testErrorInCartHooks()
+    {
+        Config::inst()->update('Order', 'extensions', ['ShoppingCartTest_TestShoppingCartErroringHooksExtension']);
+
+        ShoppingCart::singleton()->clear();
+        $cart = ShoppingCart::singleton();
+
+        $this->assertTrue((boolean)$this->cart->add($this->product, 1), "add one item");
+        $item = $cart->get($this->product);
+        $this->assertFalse(
+            (boolean)$this->cart->add($this->product, 1),
+            "Cannot add more than one item, extension will error"
+        );
+        $this->assertEquals($item->Quantity, 1, "quantity is 1");
+
+        $this->assertTrue((boolean)$cart->setQuantity($this->product, 10), "quantity set");
+        $item = $cart->get($this->product);
+        $this->assertEquals($item->Quantity, 10, "quantity is 10");
+
+        $this->assertFalse((boolean)$cart->setQuantity($this->product, 11), "Cannot set quantity to more than 10 items");
+        $item = $cart->get($this->product);
+        $this->assertEquals($item->Quantity, 10, "quantity is 10");
+    }
 }
+
+class ShoppingCartTest_TestShoppingCartHooksExtension extends Extension implements TestOnly
+{
+    public static $stack = [];
+
+    public static function reset()
+    {
+        self::$stack = [];
+    }
+
+    public function onStartOrder()
+    {
+        self::$stack[] = 'onStartOrder';
+    }
+
+    public function beforeAdd($buyable, $quantity, $filter)
+    {
+        self::$stack[] = 'beforeAdd';
+    }
+
+    public function afterAdd($item, $buyable, $quantity, $filter)
+    {
+        self::$stack[] = 'afterAdd';
+    }
+
+    public function beforeRemove($buyable, $quantity, $filter)
+    {
+        self::$stack[] = 'beforeRemove';
+    }
+
+    public function afterRemove($buyable, $quantity, $filter)
+    {
+        self::$stack[] = 'afterRemove';
+    }
+
+    public function beforeSetQuantity($buyable, $quantity, $filter)
+    {
+        self::$stack[] = 'beforeSetQuantity';
+    }
+
+    public function afterSetQuantity($item, $buyable, $quantity, $filter)
+    {
+        self::$stack[] = 'afterSetQuantity';
+    }
+}
+
+class ShoppingCartTest_TestShoppingCartErroringHooksExtension extends Extension implements TestOnly
+{
+    public function beforeSetQuantity($buyable, $quantity, $filter)
+    {
+        if($quantity > 10) {
+            throw new Exception('Invalid quantity');
+        }
+    }
+
+    public function afterAdd($item, $buyable, $quantity, $filter)
+    {
+        if($item->Quantity > 1) {
+            throw new Exception('Invalid quantity');
+        }
+    }
+}
+


### PR DESCRIPTION
This allows extensions to interrupt updates to the cart.
Update CartForm to collect/display bad messages from shopping-cart.