### PR TITLE
Update preview links for ShopEmailPreviewTask

### DIFF
--- a/code/tasks/ShopEmailPreviewTask.php
+++ b/code/tasks/ShopEmailPreviewTask.php
@@ -33,7 +33,7 @@ class ShopEmailPreviewTask extends BuildTask
     {
         $email = $request->remaining();
         $params = $request->allParams();
-        $url = "/dev/{$params['Action']}/{$params['TaskName']}";
+        $url = Director::absoluteURL("dev/{$params['Action']}/{$params['TaskName']}", true);
 
         echo '<h2>Choose Email</h2>';
         echo '<ul>';


### PR DESCRIPTION
So that they work with SilverStripe installations located in a subfolder.

Pinging @anselmdk for review.