### PR TITLE
moving the sidebar to the end of the page

### DIFF
--- a/templates/Layout/Product.ss
+++ b/templates/Layout/Product.ss
@@ -1,5 +1,4 @@
 <% require themedCSS(product,shop) %>
-<% include SideBar %>
 <div id="Product" class="typography">
     <h1 class="pageTitle">$Title</h1>
     <div class="breadcrumbs">$Breadcrumbs</div>
@@ -59,3 +58,5 @@
         </div>
     <% end_if %>
 </div>
+<% include SideBar %>
+

--- a/templates/Layout/ProductCategory.ss
+++ b/templates/Layout/ProductCategory.ss
@@ -1,5 +1,4 @@
 <% require themedCSS(productcategory,shop) %>
-<% include SideBar %>
 <div id="ProductGroup" class="typography">
     <h1 class="pageTitle">$Title</h1>
     <% if $Content %>
@@ -22,3 +21,4 @@
         </div>
     <% end_if %>
 </div>
+<% include SideBar %>


### PR DESCRIPTION
To keep the main content on top for mobile phones.
Changing the order via css is supported by frameworks like Foundation and Bootstrap. For mobile it needs to be on top though.

# Before
<img width="541" alt="screenshot 2016-10-12 12 14 24" src="https://cloud.githubusercontent.com/assets/1316533/19306445/064f8f0e-9076-11e6-8501-78efd5ef890d.png">

# After
<img width="537" alt="screenshot 2016-10-12 12 14 48" src="https://cloud.githubusercontent.com/assets/1316533/19306457/10d124ba-9076-11e6-911b-ffc90892cd9c.png">
