### PR TITLE
added extension hooks to update aditional fields

### DIFF
--- a/code/product/variations/ProductVariation.php
+++ b/code/product/variations/ProductVariation.php
@@ -266,6 +266,9 @@ class ProductVariation extends DataObject implements Buyable
         $item->ProductID = $this->ProductID;
         $item->ProductVariationID = $this->ID;
         //$item->ProductVariationVersion = $this->Version;
+
+        $this->extend('updateCreateItem', $item);
+
         if ($filter) {
             //TODO: make this a bit safer, perhaps intersect with allowed fields
             $item->update($filter);

--- a/code/product/variations/VariationForm.php
+++ b/code/product/variations/VariationForm.php
@@ -121,6 +121,8 @@ class VariationForm extends AddProductForm
                 return json_encode($ret);
             }
 
+            $this->extend('beforeVariationAddToCart', $form, $variation);
+
             if ($cart->add($variation, $quantity)) {
                 $form->sessionMessage(
                     _t('ShoppingCart.ItemAdded', "Item has been added successfully."),


### PR DESCRIPTION
Hi, 

I needed to added some extension hooks to update the field data that gets saved in the relation object. Extra fields are needed when for example someone wants to add an inscription to there product.

Firstly the extension hook in `ProductVariation::createItem()` enables me to set extra fields on the relation `$item`.

```php
public function updateCreateItem($item)
{
    $item->Inscription = $this->owner->Inscription;
}
```

Second the hook in `VariationForm::addtocart()` enables me to check if an extra field is set trough the form, and then set it on the `$variation`.

```php
public function beforeVariationAddToCart(VariationForm $form, ProductVariation $variation)
{
    $data = $form->getData();
    if (isset($data['Inscription'])) {
        $variation->Inscription = $data['Inscription'];
    }
}
```

These hooks where needed next to creating the extra field, in this case `Inscription` on the `ProductVariation`, `ProductVariation_OrderItem`.