### PR TITLE
Improve/enable custom properties on OrderItems.

### DIFF
--- a/code/cart/CartForm.php
+++ b/code/cart/CartForm.php
@@ -49,7 +49,7 @@ class CartForm extends Form
                 }
                 //delete lines
                 if (isset($fields['Remove']) || (isset($fields['Quantity']) && (int)$fields['Quantity'] <= 0)) {
-                    if (ShoppingCart::singleton()->remove($item->Buyable())) {
+                    if (ShoppingCart::singleton()->removeOrderItem($item)) {
                         $removecount++;
                     } else {
                         $badMessages[] = ShoppingCart::singleton()->getMessage();
@@ -60,7 +60,7 @@ class CartForm extends Form
                 //update quantities
                 if (isset($fields['Quantity']) && $quantity = Convert::raw2sql($fields['Quantity'])) {
                     $numericConverter->setValue($quantity);
-                    if (!ShoppingCart::singleton()->setQuantity($item->Buyable(), $numericConverter->dataValue())) {
+                    if (!ShoppingCart::singleton()->updateOrderItemQuantity($item, $numericConverter->dataValue())) {
                         $badMessages[] = ShoppingCart::singleton()->getMessage();
                     }
                 }

--- a/code/cart/MatchObjectFilter.php
+++ b/code/cart/MatchObjectFilter.php
@@ -82,6 +82,10 @@ class MatchObjectFilter
             $field = Convert::raw2sql($field);
             if (array_key_exists($field, $db)) {
                 if (isset($this->data[$field])) {
+                    // allow wildcard in filter
+                    if ($this->data[$field] === '*') {
+                        continue;
+                    }
                     $dbfield = $singleton->dbObject($field);
                     $value = $dbfield->prepValueForDB($this->data[$field]);    //product correct format for db values
                     // These seems to be a difference in how this works between SS 3.1 and 3.2

--- a/code/product/variations/VariationForm.php
+++ b/code/product/variations/VariationForm.php
@@ -121,7 +121,11 @@ class VariationForm extends AddProductForm
                 return json_encode($ret);
             }
 
-            if ($cart->add($variation, $quantity)) {
+            $saveabledata = (!empty($this->saveablefields)) ? Convert::raw2sql(
+                array_intersect_key($data, array_combine($this->saveablefields, $this->saveablefields))
+            ) : $data;
+
+            if ($cart->add($variation, $quantity, $saveabledata)) {
                 $form->sessionMessage(
                     _t('ShoppingCart.ItemAdded', "Item has been added successfully."),
                     "good"


### PR DESCRIPTION
For this to work, the following had to be changed:

 - CartForm must remove the order item by ID, not by lookup via Buyable
 - ShoppingCart must supply methods to directly remove or update an OrderItem
 - enable the “saveabledata” parameters for the VariationForm as well (not just AddProductForm)