### PR TITLE
pass the ShopAccountForm $form to the extension to be modified

### DIFF
--- a/code/account/ShopAccountForm.php
+++ b/code/account/ShopAccountForm.php
@@ -32,7 +32,7 @@ class ShopAccountForm extends Form
         }
         parent::__construct($controller, $name, $fields, $actions, $requiredFields);
 
-        $this->extend('updateShopAccountForm');
+        $this->extend('updateShopAccountForm',$this);
 
         if ($member) {
             $member->Password = ""; //prevents password field from being populated with encrypted password data


### PR DESCRIPTION
The Extension call needs a $form or $this passed as a parameter, this is so you can take the $form and change it how you wish.

If you don't pass the $form everything falls over

I'm using my extension method to remove some fields