### PR TITLE
Updated CheckoutStep_Summary.php

### DIFF
--- a/code/checkout/steps/CheckoutStep_Summary.php
+++ b/code/checkout/steps/CheckoutStep_Summary.php
@@ -26,7 +26,6 @@ class CheckoutStep_Summary extends CheckoutStep
 
         $form = PaymentForm::create($this->owner, "ConfirmationForm", $config);
         $form->setFailureLink($this->owner->Link('summary'));
-        $this->owner->extend('updateConfirmationForm', $form);
 
         return $form;
     }

--- a/code/checkout/steps/CheckoutStep_Summary.php
+++ b/code/checkout/steps/CheckoutStep_Summary.php
@@ -10,8 +10,6 @@ class CheckoutStep_Summary extends CheckoutStep
     public function summary()
     {
         $form = $this->ConfirmationForm();
-        $this->owner->extend('updateConfirmationForm', $form);
-
         return array(
             'OrderForm' => $form,
         );
@@ -26,6 +24,7 @@ class CheckoutStep_Summary extends CheckoutStep
 
         $form = PaymentForm::create($this->owner, "ConfirmationForm", $config);
         $form->setFailureLink($this->owner->Link('summary'));
+        $this->owner->extend('updateConfirmationForm', $form);
 
         return $form;
     }


### PR DESCRIPTION
The `updateConfirmationForm`form extension appears twice in the CheckoutStep_Summary class.  Remove from ConfirmationForm function and leave in the summary function, as this this closer to the final return statement.