### PR TITLE
Product price should be casted as ShopCurrency

### DIFF
--- a/code/product/Product.php
+++ b/code/product/Product.php
@@ -48,7 +48,7 @@ class Product extends Page implements Buyable
     );
 
     private static $casting                = array(
-        'Price' => 'Currency',
+        'Price' => 'ShopCurrency',
     );
 
     private static $summary_fields         = array(


### PR DESCRIPTION
Product price should be casted as ShopCurrency.

It seemed symbol changes only come through in the PriceRange function and not the standard sellingPrice function.

Changing the casting to ShopCurrency seemed to fix this.