### PR TITLE
Update composer alias for master branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
 		"installer-name": "silvershop",
 		"snapshot" : "https://raw.github.com/silvershop/silvershop-core/gh-pages/assets/screenshots/shipping%20estimate%20form.png",
 		"branch-alias": {
-			"dev-master": "1.2.x-dev"
+			"dev-master": "2.x-dev"
 		}
 	},
 	"support":{


### PR DESCRIPTION
I'm pretty sure dev-master shouldn't be an alias for 1.2 and should be for 2.2

Also, you may want to consider making it an alias for 2.x instead of 2.2.x - but I'll leave that up to you.