### PR TITLE
Remove the CostPrice field from Product.

### DIFF
--- a/docs/en/01_Getting_Set_Up/02_Upgrading.md
+++ b/docs/en/01_Getting_Set_Up/02_Upgrading.md
@@ -20,7 +20,6 @@ The Product pricing and measurement properties have generous decimal place setti
 ```yaml
 Product:
   db:
-    CostPrice: 'Currency(19,2)'
     BasePrice: 'Currency(19,2)'
     Weight: 'Decimal(12,3)'
     Height: 'Decimal(12,3)'

--- a/example_config.yml
+++ b/example_config.yml
@@ -47,7 +47,6 @@ SilverShop\Page\Product:
   # length_unit: 'M'
   # weight_unit: 'Pounds'
   db: # Revised decimal places
-    CostPrice: 'Currency(19,2)'
     BasePrice: 'Currency(19,2)'
     Weight: 'Decimal(12,3)'
     Height: 'Decimal(12,3)'

--- a/lang/da.yml
+++ b/lang/da.yml
@@ -401,7 +401,6 @@ da:
     Category: Kategori
     CategoryDescription: "Dette er den primære kategori"
     Code: 'Produkt kode'
-    CostPriceDescription: 'Engrospris før avance.'
     DESCRIPTION: 'Produkt i shoppen'
     Featured: 'Fremhævet produkt'
     Image: 'Produktbillede'
@@ -421,7 +420,6 @@ da:
     View: 'Vis produkt'
     db_AllowPurchase: 'Tillad køb'
     db_BasePrice: Pris
-    db_CostPrice: 'Kostpris'
     db_Depth: Dybde
     db_Featured: Fremhævet
     db_Height: Højde

--- a/lang/de.yml
+++ b/lang/de.yml
@@ -403,7 +403,6 @@ de:
     Category: Kategorie
     CategoryDescription: "Dies ist die übergeordnete Seite oder Standardkategorie."
     Code: 'Artikelnummer'
-    CostPriceDescription: 'Großhandelspreis ohne Preisaufschlag.'
     DESCRIPTION: 'Produkte-Seite im Shop'
     Featured: 'Hervorgehobenes Produkt'
     Image: 'Produktabbildung'
@@ -423,7 +422,6 @@ de:
     View: 'Produkt ansehen'
     db_AllowPurchase: 'Kaufen erlauben'
     db_BasePrice: Basispreis
-    db_CostPrice: 'Kostenpreis'
     db_Depth: Tiefe
     db_Featured: Hervorgehoben
     db_Height: Höhe

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -403,7 +403,6 @@ en:
     Category: Category
     CategoryDescription: "This is the parent page or default category."
     Code: 'Product Code'
-    CostPriceDescription: 'Wholesale price before markup.'
     DESCRIPTION: 'Product page in the shop'
     Featured: 'Featured Product'
     Image: 'Product Image'
@@ -423,7 +422,6 @@ en:
     View: 'View Product'
     db_AllowPurchase: 'Allow Purchase'
     db_BasePrice: Price
-    db_CostPrice: 'Cost Price'
     db_Depth: Depth
     db_Featured: Featured
     db_Height: Height

--- a/lang/fr.yml
+++ b/lang/fr.yml
@@ -403,7 +403,6 @@ fr:
     Category: Catégorie
     CategoryDescription: "Ceci est la page parente ou la catégorie par défaut"
     Code: 'Code du produit'
-    CostPriceDescription: 'Prix de gros avant majoration.'
     DESCRIPTION: 'Page du produit dans la boutique'
     Featured: 'Produit phare'
     Image: 'Image du produit'
@@ -423,7 +422,6 @@ fr:
     View: 'Voir le produit'
     db_AllowPurchase: 'Autoriser l''achat'
     db_BasePrice: Prix
-    db_CostPrice: 'Prix de revient'
     db_Depth: Profondeur
     db_Featured: Vedette
     db_Height: Hauteur

--- a/lang/nb.yml
+++ b/lang/nb.yml
@@ -403,7 +403,6 @@ nb:
     Category: Kategori
     CategoryDescription: "Dette er ei foreldreside eller standardkategori."
     Code: 'Produktkode'
-    CostPriceDescription: 'Veiledende pris, leverandørpris eller pris før varen har blitt rabattert.'
     DESCRIPTION: 'Produktside i butikken'
     Featured: 'Fremhevet produkt'
     Image: 'Produktbilde'
@@ -421,7 +420,6 @@ nb:
     View: 'Vis produkt'
     db_AllowPurchase: 'Tillat kjøp'
     db_BasePrice: Pris
-    db_CostPrice: 'Veiledende pris'
     db_Depth: Dybde
     db_Featured: Fremhevet
     db_Height: Høyde

--- a/lang/nl.yml
+++ b/lang/nl.yml
@@ -403,7 +403,6 @@ nl:
     Category: Categorie
     CategoryDescription: "Dit is de bovenliggende pagina of standaard categorie."
     Code: 'Produktcode'
-    CostPriceDescription: 'Groothandelsprijs voor prijsstijging.'
     DESCRIPTION: 'Productpagina in de winkel'
     Featured: 'Aanbevolen product'
     Image: 'Product afbeelding'
@@ -423,7 +422,6 @@ nl:
     View: 'Bekijk product'
     db_AllowPurchase: 'Sta aankoop toe'
     db_BasePrice: Prijs
-    db_CostPrice: 'Kostprijs'
     db_Depth: Diepte
     db_Featured: Aanbevolen
     db_Height: Hoogte

--- a/lang/nn.yml
+++ b/lang/nn.yml
@@ -401,7 +401,6 @@ nn:
     Category: Kategori
     CategoryDescription: "Dette er ei foreldreside eller standardkategori."
     Code: 'Produktkode'
-    CostPriceDescription: 'Rettleiande pris, leverandørpris eller pris før varen har blitt rabattert.'
     DESCRIPTION: 'Produktside i butikken'
     Featured: 'Framheva produkt'
     Image: 'Produktbilete'
@@ -421,7 +420,6 @@ nn:
     View: 'Vis produkt'
     db_AllowPurchase: 'Tillat kjøp'
     db_BasePrice: Pris
-    db_CostPrice: 'Rettleiande pris'
     db_Depth: 'Djupn '
     db_Featured: Fremheva
     db_Height: Høgde

--- a/src/Admin/ProductBulkLoader.php
+++ b/src/Admin/ProductBulkLoader.php
@@ -49,7 +49,6 @@ class ProductBulkLoader extends CsvBulkLoader
     // will be used in $duplicateChecks as well - they simply don't work.
     public $columnMap = [
         'Price' => 'BasePrice',
-        'Cost Price' => 'CostPrice',
 
         'Category' => '->setParent',
         'ProductGroup' => '->setParent',

--- a/src/Extension/ProductVariationsExtension.php
+++ b/src/Extension/ProductVariationsExtension.php
@@ -58,7 +58,6 @@ class ProductVariationsExtension extends DataExtension
                 )
             );
             $fields->removeFieldFromTab('Root.Pricing', 'BasePrice');
-            $fields->removeFieldFromTab('Root.Pricing', 'CostPrice');
             $fields->removeFieldFromTab('Root.Main', 'InternalItemID');
         }
     }

--- a/src/Page/Product.php
+++ b/src/Page/Product.php
@@ -39,7 +39,6 @@ use SilverStripe\SiteConfig\SiteConfig;
  *
  * @property string $InternalItemID
  * @property string $Model
- * @property DBCurrency $CostPrice
  * @property DBCurrency $BasePrice
  * @property DBDecimal $Weight
  * @property DBDecimal $Height
@@ -58,7 +57,6 @@ class Product extends Page implements Buyable
         'InternalItemID' => 'Varchar(30)', //ie SKU, ProductID etc (internal / existing recognition of product)
         'Model' => 'Varchar(30)',
 
-        'CostPrice' => 'Currency(19,4)', // Wholesale cost of the product to the merchant
         'BasePrice' => 'Currency(19,4)', // Base retail price the item is marked at.
 
         //physical properties
@@ -160,29 +158,26 @@ class Product extends Page implements Buyable
                 $fields->addFieldsToTab(
                     'Root.Main',
                     [
-                    TextField::create('InternalItemID', _t(__CLASS__ . '.InternalItemID', 'Product Code/SKU'), '', 30),
-                    DropdownField::create('ParentID', _t(__CLASS__ . '.Category', 'Category'), $self->getCategoryOptions())
-                    ->setDescription(_t(__CLASS__ . '.CategoryDescription', 'This is the parent page or default category.')),
-                    TextField::create('Model', _t(__CLASS__ . '.Model', 'Model'), '', 30),
-                    CheckboxField::create('Featured', _t(__CLASS__ . '.Featured', 'Featured Product')),
-                    CheckboxField::create('AllowPurchase', _t(__CLASS__ . '.AllowPurchase', 'Allow product to be purchased'), 1),
+                        TextField::create('InternalItemID', _t(__CLASS__ . '.InternalItemID', 'Product Code/SKU'), '', 30),
+                        DropdownField::create('ParentID', _t(__CLASS__ . '.Category', 'Category'), $self->getCategoryOptions())
+                            ->setDescription(_t(__CLASS__ . '.CategoryDescription', 'This is the parent page or default category.')),
+                        TextField::create('Model', _t(__CLASS__ . '.Model', 'Model'), '', 30),
+                        CheckboxField::create('Featured', _t(__CLASS__ . '.Featured', 'Featured Product')),
+                        CheckboxField::create('AllowPurchase', _t(__CLASS__ . '.AllowPurchase', 'Allow product to be purchased'), 1),
                     ]
                 );
 
                 $fields->addFieldsToTab(
                     'Root.Pricing',
                     [
-                    TextField::create('BasePrice', $this->fieldLabel('BasePrice'))
-                    ->setDescription(_t(__CLASS__ . '.PriceDesc', 'Base price to sell this product at.'))
-                    ->setMaxLength(12),
-                    TextField::create('CostPrice', $this->fieldLabel('CostPrice'))
-                    ->setDescription(_t(__CLASS__ . '.CostPriceDescription', 'Wholesale price before markup.'))
-                    ->setMaxLength(12),
+                        TextField::create('BasePrice', $this->fieldLabel('BasePrice'))
+                        ->setDescription(_t(__CLASS__ . '.PriceDesc', 'Base price to sell this product at.'))
+                        ->setMaxLength(12),
                     ]
                 );
 
                 $fieldSubstitutes = [
-                'LengthUnit' => $self::config()->length_unit
+                    'LengthUnit' => $self::config()->length_unit
                 ];
 
                 $fields->addFieldsToTab(


### PR DESCRIPTION
The `CostPrice` field is never used throughout the codebase (also checked all repositories within `silvershop`).
It only creates confusion for content-authors.

If a module uses another price-field, such as `CostPrice`, the module should add it.