### PR TITLE
change visibility of findOrMakeItem

### DIFF
--- a/code/cart/ShoppingCart.php
+++ b/code/cart/ShoppingCart.php
@@ -215,7 +215,7 @@ class ShoppingCart extends Object
      *
      * @return OrderItem the found or created item
      */
-    private function findOrMakeItem(Buyable $buyable, $filter = array())
+    protected function findOrMakeItem(Buyable $buyable, $filter = array())
     {
         $order = $this->findOrMake();
 


### PR DESCRIPTION
change visibility of findOrMakeItem  from private to protected. In order to enable overriding in subclasses (for injector)