### PR TITLE
added $item as a parameter for beforeSetQuantity

### DIFF
--- a/code/cart/ShoppingCart.php
+++ b/code/cart/ShoppingCart.php
@@ -271,7 +271,7 @@ class ShoppingCart extends Object
         $buyable = $item->Buyable();
         // If an extension throws an exception, error out
         try {
-            $order->extend("beforeSetQuantity", $buyable, $quantity, $filter);
+            $order->extend("beforeSetQuantity", $buyable, $quantity, $filter, $item);
         } catch (Exception $exception){
             return $this->error($exception->getMessage());
         }


### PR DESCRIPTION
This keeps it in line with the `afterSetQuantity`, allowing for more flexibility. Note however it is added as a fourth parameter, which differs from `afterSetQuantity` but it keeps the integrity of the public API;