### PR TITLE
Restore previous field positions 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,20 +9,14 @@ env:
 
 matrix:
   include:
-    - php: 5.6
-      env: DB=PGSQL CORE_RELEASE=3.2 COVERAGE=1
-    - php: 5.6
-      env: DB=PGSQL CORE_RELEASE=3.2 COVERAGE=2
-    - php: 5.6
-      env: DB=PGSQL CORE_RELEASE=3.2 COVERAGE=3
-    - php: 7.0
-      env: DB=PGSQL CORE_RELEASE=3.6
     - php: 5.5
       env: DB=SQLITE CORE_RELEASE=3.1
+    - php: 5.6
+      env: DB=MYSQL CORE_RELEASE=3.2
     - php: 7.0
-      env: DB=PGSQL CORE_RELEASE=master
-  allow_failures:
-    - env: DB=PGSQL CORE_RELEASE=master
+      env: DB=PGSQL CORE_RELEASE=3.6 COVERAGE=1
+    - php: 7.0
+      env: DB=PGSQL CORE_RELEASE=3.7
 
 before_script:
   - composer self-update
@@ -35,11 +29,3 @@ before_script:
 script: ./silvershop/tests/travis/run_build.sh
 
 after_success: ./silvershop/tests/travis/upload_coverage.sh
-
-notifications:
-  webhooks:
-    urls:
-      - 'https://webhooks.gitter.im/e/a3720004986a0f249abc'
-    on_success: change
-    on_failure: always
-    on_start: false

--- a/code/product/Product.php
+++ b/code/product/Product.php
@@ -126,7 +126,7 @@ class Product extends Page implements Buyable
                 TextField::create('Model', _t('Product.Model', 'Model'), '', 30),
                 CheckboxField::create('Featured', _t('Product.Featured', 'Featured Product')),
                 CheckboxField::create('AllowPurchase', _t('Product.AllowPurchase', 'Allow product to be purchased'), 1),
-            ]);
+            ], 'Content');
 
             $fields->addFieldsToTab('Root.Pricing', [
                 TextField::create('BasePrice', _t('Product.db_BasePrice', 'Price'))

--- a/tests/account/OrderActionsFormTest.php
+++ b/tests/account/OrderActionsFormTest.php
@@ -26,6 +26,7 @@ class OrderActionsFormTest extends FunctionalTest
         $this->checkoutPage->publish('Stage', 'Live');
 
         Config::inst()->update('Payment', 'allowed_gateways', array('Dummy'));
+        Config::inst()->update('GatewayInfo', 'Dummy', array('is_offsite' => false));
     }
 
     public function testOffsitePayment()

--- a/tests/checkout/SteppedCheckoutTest.php
+++ b/tests/checkout/SteppedCheckoutTest.php
@@ -24,6 +24,8 @@ class SteppedCheckoutTest extends FunctionalTest
     {
         parent::setUp();
         ShopTest::setConfiguration();
+        Config::inst()->update('GatewayInfo', 'Dummy', array('is_offsite' => false));
+
         //set up steps
         SteppedCheckout::setupSteps(); //use default steps
 
@@ -164,6 +166,7 @@ class SteppedCheckoutTest extends FunctionalTest
 
     public function testSummary()
     {
+        $this->useDraftSite(false);
         $this->checkout->summary();
         $form = $this->checkout->ConfirmationForm();
         $data = array(


### PR DESCRIPTION
(fields were previously positioned _before_ the `Content` field)

Update/fix unit-tests.