### PR TITLE
Fixes admin interface ss41

### DIFF
--- a/example_config.yml
+++ b/example_config.yml
@@ -83,3 +83,7 @@ SilverShop\Cart\ShoppingCartController:
   direct_to_cart_page: true
   # disable security token for cart-links
   disable_security_token: true
+
+SilverShop\Reports\ShopPeriodReport:
+  # IF you are using the silverware/calendar module, uncomment the following line
+  #disable_set_date_format: true

--- a/src/Extension/ShopConfigExtension.php
+++ b/src/Extension/ShopConfigExtension.php
@@ -113,7 +113,7 @@ class ShopConfigExtension extends DataExtension
         asort($countries);
         if ($allowed = $this->owner->AllowedCountries) {
             $allowed = json_decode($allowed);
-            if (!is_null($allowed) && count($allowed) > 0) {
+            if (!empty($allowed)) {
                 $countries = array_intersect_key($countries, array_flip($allowed));
             }
         }

--- a/src/Extension/ShopConfigExtension.php
+++ b/src/Extension/ShopConfigExtension.php
@@ -113,7 +113,7 @@ class ShopConfigExtension extends DataExtension
         asort($countries);
         if ($allowed = $this->owner->AllowedCountries) {
             $allowed = json_decode($allowed);
-            if (count($allowed) > 0) {
+            if (!is_null($allowed) && count($allowed) > 0) {
                 $countries = array_intersect_key($countries, array_flip($allowed));
             }
         }

--- a/src/ORM/Filters/MultiFieldPartialMatchFilter.php
+++ b/src/ORM/Filters/MultiFieldPartialMatchFilter.php
@@ -65,7 +65,7 @@ class MultiFieldPartialMatchFilter extends PartialMatchFilter
             }
         );
 
-        if (!is_null($this->subfilters) && count($this->subfilters) > 0) {
+        if (!empty($this->subfilters)) {
             foreach ($this->subfilters as $f) {
                 $f->setModifiers($this->subfilterModifiers);
             }

--- a/src/ORM/Filters/MultiFieldPartialMatchFilter.php
+++ b/src/ORM/Filters/MultiFieldPartialMatchFilter.php
@@ -65,7 +65,7 @@ class MultiFieldPartialMatchFilter extends PartialMatchFilter
             }
         );
 
-        if (count($this->subfilters) > 0) {
+        if (!is_null($this->subfilters) && count($this->subfilters) > 0) {
             foreach ($this->subfilters as $f) {
                 $f->setModifiers($this->subfilterModifiers);
             }

--- a/src/Reports/ShopPeriodReport.php
+++ b/src/Reports/ShopPeriodReport.php
@@ -78,8 +78,14 @@ abstract class ShopPeriodReport extends Report implements i18nEntityProvider
                 );
             }
         }
-        $start->setDateFormat($dateformat);
-        $end->setDateFormat($dateformat);
+
+        // When using silverware/calendar package, setting the date format breaks the admin interface.  Leave default
+        // behavior as was, but allow the date format not to be set as a config override
+        if ($this->config()->get('disable_set_date_format') != true) {
+            $start->setDateFormat($dateformat);
+            $end->setDateFormat($dateformat);
+        }
+
         return $fields;
     }
 


### PR DESCRIPTION
With the default config settings I've had to make these changes to get the admin interface not breaking with SS41.

The following were broken:

* Viewing list of orders
* Viewing a single order
* Shop reports where a date range was included.  I've added a config override here, but the default behavior should be the same as it was before.