### PR TITLE
Updated example_config.yml

### DIFF
--- a/example_config.yml
+++ b/example_config.yml
@@ -43,7 +43,7 @@ SilverShop\Forms\OrderActionsForm:
 #  send_admin_notification: true  # copy to admin
 
 SilverShop\Page\Product:
-  global_allow_purchase: false
+  # global_allow_purchase: false # prevents the purchase of any product and disables adding to cart
   # length_unit: 'M'
   # weight_unit: 'Pounds'
   db: # Revised decimal places


### PR DESCRIPTION
Commented out `global_allow_purchase: false` so that the cart can be added to immediately following use of example_config.yml in a new site