### PR TITLE
CheckoutPage_membership should be treated as Layout

### DIFF
--- a/src/Checkout/Step/Membership.php
+++ b/src/Checkout/Step/Membership.php
@@ -57,7 +57,9 @@ class Membership extends CheckoutStep
             ]
         )->renderWith(
             [
-                'SilverShop\Page\Layout\CheckoutPage_membership', CheckoutPage::class, 'Page'
+                'SilverShop\Page\CheckoutPage_membership',
+                CheckoutPage::class,
+                'Page'
             ]
         ); //needed to make rendering work on index
     }


### PR DESCRIPTION
Without explicitely using "Layout" in the template name it gets wrapped
in global Page.ss which is the desired behaviour