### PR TITLE
Exclude deprecations from custom error handler

### DIFF
--- a/src/Checkout/OrderProcessor.php
+++ b/src/Checkout/OrderProcessor.php
@@ -306,7 +306,7 @@ class OrderProcessor
             function ($severity, $message, $file, $line) {
                 throw new ErrorException($message, 0, $severity, $file, $line);
             },
-            E_ALL & ~(E_STRICT | E_NOTICE)
+            E_ALL & ~(E_STRICT | E_NOTICE | E_DEPRECATED | E_USER_DEPRECATED)
         );
 
         try {


### PR DESCRIPTION
Fixes an error, where no emails / receipts are sent, when an order is paid (via payment provider). We have local mail set up , no SMTP. The problem is, that Swift standard transport is deprecated and throws a E_USER_DEPRECATED error which is now ignored.