### PR TITLE
Use Label as title for frontend dropdown field

### DIFF
--- a/src/Model/Variation/AttributeType.php
+++ b/src/Model/Variation/AttributeType.php
@@ -146,7 +146,7 @@ class AttributeType extends DataObject
         if ($values->exists()) {
             $field = DropdownField::create(
                 'ProductAttributes[' . $this->ID . ']',
-                $this->Name,
+                $this->Label,
                 $values->map('ID', 'Value')
             );
 


### PR DESCRIPTION
In the frontend dropdown the Label field should be used instead of the Name field.
This is mentioned in the source:

```
    private static $db = [
        'Name' => 'Varchar', //for back-end use
        'Label' => 'Varchar' //for front-end use
    ];
```
