### PR TITLE
Order Link function should point to account if logged in

### DIFF
--- a/src/Model/Order.php
+++ b/src/Model/Order.php
@@ -507,11 +507,11 @@ class Order extends DataObject
      */
     public function Link()
     {
+        $link = CheckoutPage::find_link(false, 'order', $this->ID);
+        
         if (Security::getCurrentUser()) {
             $link = Controller::join_links(AccountPage::find_link(), 'order', $this->ID);
         }
-
-        $link = CheckoutPage::find_link(false, 'order', $this->ID);
 
         $this->extend('updateLink', $link);
 


### PR DESCRIPTION
Changed the order so that if Logged in user is sent to account page instead of checkout page.