### PR TITLE
Add unique modifiers from the config

### DIFF
--- a/src/Cart/OrderTotalCalculator.php
+++ b/src/Cart/OrderTotalCalculator.php
@@ -50,7 +50,7 @@ class OrderTotalCalculator
         $runningtotal = $this->order->SubTotal();
         $sort = 1;
         $existingmodifiers = $this->order->Modifiers();
-        $modifierclasses = Order::config()->modifiers;
+        $modifierclasses = array_unique(Order::config()->modifiers);
 
         //check if modifiers are even in use
         if (!is_array($modifierclasses) || empty($modifierclasses)) {


### PR DESCRIPTION
Currently if modifier is already defined in a third party config, defining the modifier in the main app cause errors. This pull request will make sure that only unique set of modifiers from the config is used.