### PR TITLE
Misc fixes made during project

### DIFF
--- a/src/Checkout/OrderProcessor.php
+++ b/src/Checkout/OrderProcessor.php
@@ -291,7 +291,6 @@ class OrderProcessor
             $this->order->Status = 'Unpaid';
         } else {
             $this->order->Status = 'Paid';
-            $this->order->Paid = DBDatetime::now()->Rfc2822();
         }
 
         if (!$this->order->Placed) {

--- a/src/Checkout/OrderProcessor.php
+++ b/src/Checkout/OrderProcessor.php
@@ -291,6 +291,7 @@ class OrderProcessor
             $this->order->Status = 'Unpaid';
         } else {
             $this->order->Status = 'Paid';
+            $this->order->Paid = DBDatetime::now()->Rfc2822();
         }
 
         if (!$this->order->Placed) {

--- a/src/Model/Order.php
+++ b/src/Model/Order.php
@@ -435,9 +435,6 @@ class Order extends DataObject
      */
     public function calculate()
     {
-        if (!$this->IsCart()) {
-            return $this->Total;
-        }
         $calculator = OrderTotalCalculator::create($this);
         return $this->Total = $calculator->calculate();
     }

--- a/src/Model/Order.php
+++ b/src/Model/Order.php
@@ -19,6 +19,7 @@ use SilverStripe\Forms\CheckboxSetField;
 use SilverStripe\Forms\DateField;
 use SilverStripe\Forms\DropdownField;
 use SilverStripe\Forms\FieldList;
+use SilverStripe\Forms\GridField\GridField;
 use SilverStripe\Forms\LiteralField;
 use SilverStripe\Forms\Tab;
 use SilverStripe\Forms\TabSet;
@@ -310,7 +311,11 @@ class Order extends DataObject
             $parts[] = LiteralField::create('Notes', $fs . $this->renderWith('SilverShop\Admin\OrderAdmin_Notes') . $fe);
         }
         $fields->addFieldsToTab('Root.Main', $parts);
+
+        $fields->addFieldToTab('Root.Modifiers', new GridField('Modifiers', 'Modifiers', $this->Modifiers()));
+
         $this->extend('updateCMSFields', $fields);
+
         if ($payments = $fields->fieldByName('Root.Payments.Payments')) {
             $fields->removeByName('Payments');
             $fields->insertAfter('Content', $payments);

--- a/src/Model/Variation/Variation.php
+++ b/src/Model/Variation/Variation.php
@@ -317,6 +317,17 @@ class Variation extends DataObject implements Buyable
         return $this->Item()->addLink($this->ProductID, $this->ID);
     }
 
+    /**
+     * Returns a link to the parent product of this variation (variations don't have their own pages)
+     *
+     * @param $action string
+     *
+     * @return string
+     */
+    public function Link($action = null) {
+        return ($this->ProductID) ? $this->Product()->Link($action) : false;
+    }
+
     public function createItem($quantity = 1, $filter = array())
     {
         $orderitem = self::config()->order_item;


### PR DESCRIPTION
During a recent upgrade project, we reviewed an old fork that we were on of silverstripe-shop (the precursor to silvershop).

During this, I found the following changes that were missing from silvershop-core, there are four distinct things that we've added / resolved (each commit is a single fix/change that we've made).

The four changes are:
- Fix OrderProcessor not setting the paid date when an order has nothing outstanding
- Show any OrderModifiers added to the order when viewing order details in CMS
- Allow order total calculation to always include any applied discounts/coupons
- Provide a Link method for product variations that links to the product page

I'm happy to raise these as individual pull requests if you'd prefer, but thought that all four are relatively benign so it made sense to just raise them at the same time. Let me know if you'd prefer I separate them.

Thanks!