### PR TITLE
FEAT: Add new VisibleToCustomer flag to OrderStatusLog

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # SilverShop ChangeLog
 
+## Unreleased 3.x
+
+- Add new `VisibleToCustomer` flag to `OrderStatusLog`. Use it alongside the existing `SentToCustomer` flags to allow developers to store additional admin-only log messages attached to orders.
+
 ## 3.0.0
 
 Introduces SilverStripe 4 support and full namespaces.

--- a/src/Checkout/OrderEmailNotifier.php
+++ b/src/Checkout/OrderEmailNotifier.php
@@ -212,8 +212,8 @@ class OrderEmailNotifier
             // Find the latest log message that hasn't been sent to the client yet, but can be (e.g. is visible)
             $latestLog = OrderStatusLog::get()
                 ->filter("OrderID", $this->order->ID)
-                ->filter("SentToCustomer", false)
-                ->filter("VisibleToCustomer", true)
+                ->filter("SentToCustomer", 0)
+                ->filter("VisibleToCustomer", 1)
                 ->first();
 
             if ($latestLog) {

--- a/src/Model/Order.php
+++ b/src/Model/Order.php
@@ -889,7 +889,8 @@ class Order extends DataObject
             $log->Note = _t('SilverShop\ShopEmail.StatusChange' . $this->Status . 'Note', $this->Status . 'Note');
             $log->OrderID = $this->ID;
             OrderEmailNotifier::create($this)->sendStatusChange($log->Title, $log->Note);
-            $log->SentToCustomer = true;
+            $log->SentToCustomer = true; // Explicitly set because sendStatusChange() won't set it in this case
+            $log->VisibleToCustomer = true;
             $this->extend('updateOrderStatusLog', $log);
             $log->write();
         }


### PR DESCRIPTION
Should be backwards-compatible. Includes an upgrade task that correctly sets the flag for old records

- Add new boolean flag VisibleToCustomer to OrderStatusLog
- Add requireDefaultRecords to migrate and upsert the new VisibleToCustomer flag to existing records
- Add description for existing SentToCustomer field (after discussion on it's purpose with wilr) and VisibleToCustomer
- Set new flag appropriately in existing logic
- Add note to changelog for an upcoming (unreleased) version