### PR TITLE
FEAT: Allow OrderStatusLog objects to *not* be forcibly linked to an order

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,7 @@
 ## Unreleased 3.x
 
 - Add new `VisibleToCustomer` flag to `OrderStatusLog`. Use it alongside the existing `SentToCustomer` flags to allow developers to store additional admin-only log messages attached to orders.
+- Add new `order_is_required` config flag to `OrderStatusLog`, set to true by default (for backwards-compatibility). Set it to `false` to allow `OrderStatusLog` objects to be created that are not linked to any particular `Order` object.
 
 ## 3.0.0
 

--- a/src/Model/OrderStatusLog.php
+++ b/src/Model/OrderStatusLog.php
@@ -79,6 +79,13 @@ class OrderStatusLog extends DataObject
 
     private static $table_name = 'SilverShop_OrderStatusLog';
 
+    /**
+     * @var bool Whether the link between an Order and OrderStatusLog is required (tested during write validation)
+     * @see static::validate()
+     * @config
+     */
+    private static $order_is_required = true;
+
     public function canCreate($member = null, $context = [])
     {
         return false;
@@ -143,9 +150,11 @@ class OrderStatusLog extends DataObject
     public function validate()
     {
         $validationResult = parent::validate();
-        if (!$this->OrderID) {
+
+        if (!$this->OrderID && $this->config()->order_is_required) {
             $validationResult->addError('there is no order id for Order Status Log');
         }
+
         return $validationResult;
     }
 

--- a/tests/php/Model/OrderStatusLogTest.php
+++ b/tests/php/Model/OrderStatusLogTest.php
@@ -321,4 +321,24 @@ class OrderStatusLogTest extends SapphireTest
             'Silvershop - ' . $log_order_status_processing->Title
         );
     }
+
+    public function testOrderIsRequired()
+    {
+        $log = new OrderStatusLog([
+            'Title' => 'Test',
+            'OrderID' => 1
+        ]);
+        $log->write();
+        $this->assertTrue($log->exists());
+
+        // Now we make sure we don't need to set an OrderID
+        Config::modify()->set(OrderStatusLog::class, 'order_is_required', false);
+
+        $log = new OrderStatusLog([
+            'Title' => 'Test'
+        ]);
+
+        $log->write();
+        $this->assertTrue($log->exists());
+    }
 }


### PR DESCRIPTION
As per description. Added the following the the changelog which describes the feature:

Add new `order_is_required` config flag to `OrderStatusLog`, set to true by default (for backwards-compatibility). Set it to `false` to allow `OrderStatusLog` objects to be created that are not linked to any particular `Order` object.

This change is backwards-compatible to 3.0.0.