### PR TITLE
FEAT: Add table index for Status and the Status/Placed/Created tuple

### DIFF
--- a/src/Model/Order.php
+++ b/src/Model/Order.php
@@ -115,6 +115,14 @@ class Order extends DataObject
         'OrderStatusLogs' => OrderStatusLog::class,
     ];
 
+    private static $indexes = [
+        'Status' => true,
+        'StatusPlacedCreated' => [
+            'type' => 'index',
+            'columns' => ['Status', 'Placed', 'Created']
+        ]
+    ];
+
     private static $defaults = [
         'Status' => 'Cart',
     ];


### PR DESCRIPTION
This allows for much faster DB queries when searching for 'Cart' orders, something silvershop now does I think when viewing any product page.

On a database that has ~200k randomly generated fake orders, average query times are:
| Description | Time | Notes |
|-------|-----|-----|
| Before any indexes | **1.3s** | MySQL using filesort, 200k rows |
| After adding 'Status' index only | **1.1ms** | Still using filesort, but on only 20 'Cart' rows |
| After adding both indexes | **0.8ms** | No filesort anymore |

