### PR TITLE
FIX: Replace Image::Fit() with Image::Pad()

### DIFF
--- a/src/Extension/ProductImageExtension.php
+++ b/src/Extension/ProductImageExtension.php
@@ -78,7 +78,7 @@ class ProductImageExtension extends DataExtension
         if ($width && $height) {
             return $realWidth < $width && $realHeight < $height && !$upscale
                 ? $this->owner
-                : $this->owner->Fit($width, $height);
+                : $this->owner->Pad($width, $height);
         } else {
             if ($width) {
                 return $realWidth < $width && !$upscale


### PR DESCRIPTION
- per Silverstripe 4.0 Filesystem changelog: https://docs.silverstripe.org/en/4/changelogs/4.0.0/#overview-filesystem, Image::SetSize() should be replaced with Image::Pad()
- fixes incorrect image size displayed on shop