### PR TITLE
Get the dbObject instance of the PurchaseComplete message

### DIFF
--- a/src/Checkout/OrderEmailNotifier.php
+++ b/src/Checkout/OrderEmailNotifier.php
@@ -64,7 +64,7 @@ class OrderEmailNotifier
         $from = ShopConfigExtension::config()->email_from ? ShopConfigExtension::config()->email_from : Email::config()->admin_email;
         $to = $this->order->getLatestEmail();
         $checkoutpage = CheckoutPage::get()->first();
-        $completemessage = $checkoutpage ? $checkoutpage->PurchaseComplete : '';
+        $completemessage = $checkoutpage ? $checkoutpage->dbObject('PurchaseComplete') : '';
 
         /**
          * @var Email $email


### PR DESCRIPTION
By passing the HTMLText object the text renders properly in the email