### PR TITLE
Don't throw exceptions for suppressed errors

### DIFF
--- a/src/Checkout/OrderProcessor.php
+++ b/src/Checkout/OrderProcessor.php
@@ -304,6 +304,10 @@ class OrderProcessor
         // in the following block.
         set_error_handler(
             function ($severity, $message, $file, $line) {
+                if (!(error_reporting() & $severity)) {
+                    // suppressed error, for example from exif_read_data in image manipulation
+                    return false;
+                }
                 throw new ErrorException($message, 0, $severity, $file, $line);
             },
             E_ALL & ~(E_STRICT | E_NOTICE | E_DEPRECATED | E_USER_DEPRECATED)


### PR DESCRIPTION
Don't throw exceptions for suppressed errors in the custom error handler in OrderProcessor when placing an order.
The error use case we encountered is when sending an order receipt e-mail that uses some image manipulation functions (for example FitMax) in the e-mail template. If the original image includes incorrect exif data, then intervention image will still try to orient the image, using exif_read_data which in turn triggers an error. Even though the exif_read_data call suppresses errors via the @ operator, the custom error handler in OrderProcessor is still triggered and throws an Exception, which causes intervention image to believe the image cannot be read and the image manipulation is skipped.
The solution is to simply check the error reporting level and error severity in the custom error handler, according to the php documentation on error control operators, see: https://www.php.net/manual/en/language.operators.errorcontrol.php