### PR TITLE
Allow overriding of latest email for order

### DIFF
--- a/docs/en/02_Customisation/OrderStatusEmailNotifications.md
+++ b/docs/en/02_Customisation/OrderStatusEmailNotifications.md
@@ -29,6 +29,6 @@ To override the default recipient email address form notifications, add the bell
 ```php
 public function overrideLatestEmail() 
 {
-  return 'override@email.com
+  return 'override@email.com';
 }
 ```

--- a/docs/en/02_Customisation/OrderStatusEmailNotifications.md
+++ b/docs/en/02_Customisation/OrderStatusEmailNotifications.md
@@ -25,3 +25,10 @@ en:
 ```
 To further customise the email, copy the template `Order_StatusEmail.ss` from `silvershop/templates/email` folder and paste to `{yourtheme}/templates/email` and make the required adjustments.
 
+To override the default recipient email address form notifications, add the bellow method to a SilverShop\Model\Order.php extension.
+```php
+public function overrideLatestEmail() 
+{
+  return 'override@email.com
+}
+```

--- a/src/Model/Order.php
+++ b/src/Model/Order.php
@@ -652,6 +652,9 @@ class Order extends DataObject
      */
     public function getLatestEmail()
     {
+        if ($this->hasMethod('overrideLatestEmail')) {
+            return $this->overrideLatestEmail();
+        }
         if ($this->MemberID && ($this->Member()->LastEdited > $this->LastEdited || !$this->Email)) {
             return $this->Member()->Email;
         }


### PR DESCRIPTION
This will allow for a nieche scenario where a user may desire to change their email used for order notifications without affecting the email used for logging in, payments etc.