### PR TITLE
Cleanup: Remove useless Product::Link() method

### DIFF
--- a/src/Page/Product.php
+++ b/src/Page/Product.php
@@ -442,13 +442,6 @@ class Product extends Page implements Buyable
         return false;
     }
 
-    public function Link($action = null)
-    {
-        $link = parent::Link($action);
-        $this->extend('updateLink', $link);
-        return $link;
-    }
-
     /**
      * If the product does not have an image, and a default image
      * is defined in SiteConfig, return that instead.


### PR DESCRIPTION
as it doesn't provide any custom value over `parent::Link()`

fixes #772