### PR TITLE
Recalculated Order should be saved

### DIFF
--- a/src/Forms/PaymentForm.php
+++ b/src/Forms/PaymentForm.php
@@ -90,7 +90,11 @@ class PaymentForm extends CheckoutForm
 
         // final recalculation, before making payment
         $order->calculate();
-
+        
+        if ($order->isChanged()) {
+            $order->write();
+        }
+        
         // handle cases where order total is 0. Note that the order will appear
         // as "paid", but without a Payment record attached.
         if ($order->GrandTotal() == 0 && Order::config()->allow_zero_order_total) {


### PR DESCRIPTION
Under certain circumstances an order with different modifiers (e.g. discount, free-shipping with min. price) can calculate a new total-price before it is submitted to the payment-gateway. The changed total-price should be saved before the submit to avoid miscalculations afterwards. Problems occur when place_before_payment is switched off.