### PR TITLE
Silverstripe 5 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,12 +21,12 @@
     }
   ],
   "require": {
-    "silverstripe/cms": "^4.10",
+    "silverstripe/cms": "^4.10 | ^5",
     "silverstripe/asset-admin": "*",
-    "silverstripe/silverstripe-omnipay": "^3@dev",
-    "silvershop/silverstripe-listsorter": "^3@dev",
-    "silvershop/silverstripe-sqlquerylist": "^2@dev",
-    "symbiote/silverstripe-gridfieldextensions": "^3.2"
+    "silverstripe/silverstripe-omnipay": "^3@dev | ^4@dev",
+    "silvershop/silverstripe-listsorter": "^3@dev | ^4@dev",
+    "silvershop/silverstripe-sqlquerylist": "^2@dev | ^3@dev",
+    "symbiote/silverstripe-gridfieldextensions": "^3.2 | ^4"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.5",

--- a/composer.json
+++ b/composer.json
@@ -23,9 +23,9 @@
   "require": {
     "silverstripe/cms": "^4.10 | ^5",
     "silverstripe/asset-admin": "*",
-    "silverstripe/silverstripe-omnipay": "^3@dev | ^4@dev",
-    "silvershop/silverstripe-listsorter": "^3@dev | ^4@dev",
-    "silvershop/silverstripe-sqlquerylist": "^2@dev | ^3@dev",
+    "silverstripe/silverstripe-omnipay": "^3@dev | dev-main#8f277fa5ef513ded38e55ed3c56778feada26174",
+    "silvershop/silverstripe-listsorter": "^3@dev | dev-upgrade/ss5",
+    "silvershop/silverstripe-sqlquerylist": "^2@dev | dev-upgrade/ss5",
     "symbiote/silverstripe-gridfieldextensions": "^3.2 | ^4"
   },
   "require-dev": {


### PR DESCRIPTION
I've started the work to upgrade this module to Silverstripe 5 and have managed it with very few changes required. 

- [x] upgrade this module for SS5 support 
- [x] upgrade silverstripe/silverstripe-omnipay for SS5 ([merged, needs stable tag](https://github.com/silverstripe/silverstripe-omnipay/commit/8f277fa5ef513ded38e55ed3c56778feada26174))
- [x] upgrade silvershop/silverstripe-listsorter ([merged, tagged 3.0.0](https://github.com/silvershop/silverstripe-listsorter/commit/d5835bde1e8d4a4502dcb1ede08e21b94a279650))
- [x] upgrade silvershop/silverstripe-sqlquerylist ([merged, needs stable tag](https://github.com/silvershop/silverstripe-sqlquerylist/commit/ee11995363b57e2282161d488c0dc732b60082a3))

It's not mergeable as-is unless you add my forks to the repositories key to your parent project (composer seems to ignore the upstream ones).  The pull requests need to be accepted, so I can update this pull request to use a stable tag, or a specific commit until it is marked stable
```
    "repositories": {
        "silvershop/core": {
            "type": "vcs",
            "url": "git@github.com:elliot-sawyer/silvershop-core.git"
        },
        "silvershop/silverstripe-listsorter": {
            "type": "vcs",
            "url": "git@github.com:elliot-sawyer/silverstripe-listsorter.git"
        },
        "silvershop/silverstripe-sqlquerylist": {
            "type": "vcs",
            "url": "git@github.com:elliot-sawyer/silverstripe-sqlquerylist.git"
        }
    },
```

The only coding change required was on sqlquerylist, which changed the method signature on `limit` to support type hinting and return types. There may be more to be checked inside the tests, but I haven't gone into those.

Once those upstream dependencies are merged in, this should be safe to merge
