### PR TITLE
Fix $this->addresstype only contains EN value

### DIFF
--- a/client/dist/javascript/CheckoutPage.nojquery.js
+++ b/client/dist/javascript/CheckoutPage.nojquery.js
@@ -1,0 +1,41 @@
+/**
+ *     Addressbook checkout component
+ *     This handles a dropdown or radio buttons containing existing addresses or payment methods,
+ *     with one of the options being "create a new ____". When that last option is selected, the
+ *     other fields need to be shown, otherwise they need to be hidden.
+ */
+function onExistingValueChange() {
+    let existingValues = document.querySelectorAll('.hasExistingValues');
+    if(!existingValues) return;
+
+    existingValues.forEach(function (container, idx) {
+        let toggle = document.querySelector('.existingValues select, .existingValues input:checked');
+
+        // visible if the value is not an ID (numeric)
+        let toggleState = Number.isNaN(parseInt(toggle.value));
+        let toggleFields = container.querySelectorAll(".field:not(.existingValues)");
+
+        // animate the fields - hide or show
+        if (toggleFields && toggleFields.length > 0) {
+            toggleFields.forEach(field => {
+                field.style.display = toggleState ? '' : 'none';
+            })
+        }
+
+        // clear them out
+        toggleFields.forEach(field => {
+            field.querySelectorAll('input, select, textarea').forEach(f => {
+                f.value = '';
+                f.disabled = toggleState ? '' : 'disabled';
+            });
+        });
+    });
+}
+
+let selectors = document.querySelectorAll('.existingValues select');
+if(selectors) selectors.forEach(selector => selector.addEventListener('change', onExistingValueChange));
+
+let inputs = document.querySelectorAll('.existingValues input[type=radio]')
+if(inputs) inputs.forEach(input => input.addEventListener('click', onExistingValueChange));
+
+onExistingValueChange(); // handle initial state

--- a/src/Checkout/Component/AddressBook.php
+++ b/src/Checkout/Component/AddressBook.php
@@ -72,7 +72,7 @@ abstract class AddressBook extends Address implements i18nEntityProvider
         $member = Security::getCurrentUser();
         if ($member && $member->AddressBook()->exists()) {
             $addressoptions = $member->AddressBook()->sort('Created', 'DESC')->map('ID', 'toString')->toArray();
-            $addressoptions['newaddress'] = _t('SilverShop\Model\Address.CreateNewAddress', 'Create new address');
+            $addressoptions['newaddress'] = _t('SilverShop\Model\Address.CreateNewAddress', 'Create new {AddressType} address', '', ["AddressType" => $this->addresstype]);
             $fieldtype = count($addressoptions) > 3 ? DropdownField::class : OptionsetField::class;
 
             $label = _t("SilverShop\Model\Address.Existing{$this->addresstype}Address", "Existing {$this->addresstype} Address");

--- a/src/Checkout/Component/AddressBook.php
+++ b/src/Checkout/Component/AddressBook.php
@@ -37,9 +37,10 @@ abstract class AddressBook extends Address implements i18nEntityProvider
         if ($existingaddressfields = $this->getExistingAddressFields()) {
             if ($jquery = $this->config()->get('jquery_file')) {
                 Requirements::javascript($jquery);
+                Requirements::javascript('silvershop/core:client/dist/javascript/CheckoutPage.js');
+            } else {
+                Requirements::javascript('silvershop/core:client/dist/javascript/CheckoutPage.nojquery.js');
             }
-
-            Requirements::javascript('silvershop/core:client/dist/javascript/CheckoutPage.js');
 
             // add the fields for a new address after the dropdown field
             $existingaddressfields->merge($fields);


### PR DESCRIPTION
I provided a new variable which now holds the translated AddressType for types Billing and Shipping. The default EN value remains as fallback as there were customizations made, like renaming the type in an extension