### PR TITLE
Update Order.php

### DIFF
--- a/src/Model/Order.php
+++ b/src/Model/Order.php
@@ -707,7 +707,7 @@ class Order extends DataObject
         $address = $this->getComponent($type . 'Address');
 
         if (!$address || !$address->exists() && $this->Member()) {
-            $address = $this->Member()->{"Default${type}Address"}();
+            $address = $this->Member()->{"Default{$type}Address"}();
         }
 
         if (empty($address->Surname) && empty($address->FirstName)) {


### PR DESCRIPTION
FIX PHP 8.2 warning of a future depreciation, “PHP Deprecated:  Using ${var} in strings is deprecated, use {$var} instead.”  Thank you.