### PR TITLE
Fix currency formatting

### DIFF
--- a/client/dist/css/shopcms.css
+++ b/client/dist/css/shopcms.css
@@ -43,3 +43,7 @@ Integrated webfont. Created via http://fontello.com/
   .shop-order__address {
     vertical-align: top;
   }
+
+  td.col-TotalNice {
+    text-align: right;
+  }

--- a/client/dist/css/shopcms.css
+++ b/client/dist/css/shopcms.css
@@ -44,6 +44,7 @@ Integrated webfont. Created via http://fontello.com/
     vertical-align: top;
   }
 
-  td.col-TotalNice {
+  td.col-TotalNice,
+  td.col-Amount-Nice{
     text-align: right;
   }

--- a/client/dist/css/shopcms.css
+++ b/client/dist/css/shopcms.css
@@ -45,6 +45,10 @@ Integrated webfont. Created via http://fontello.com/
   }
 
   td.col-TotalNice,
-  td.col-Amount-Nice{
+  td.col-TotalValue,
+  td.col-Amount-Nice,
+  td.col-BasePrice,
+  td.col-Sales,
+  td.col-Spent {
     text-align: right;
   }

--- a/lang/de.yml
+++ b/lang/de.yml
@@ -243,6 +243,7 @@ de:
     ShipTo: 'Lieferung an'
     SubTotal: Zwischensumme
     Total: Gesamt
+    TotalNice: Gesamt
     TotalOutstanding: 'Gesamt ausstehend'
     TotalPrice: 'Gesamtpreis'
     TotalPriceWithCurrency: 'Gesamtpreis ({Currency})'

--- a/lang/en.yml
+++ b/lang/en.yml
@@ -261,6 +261,7 @@ en:
     db_Status: Status
     db_Surname: Surname
     db_Total: Total
+    TotalNice: Total
     has_many_Items: Items
     has_many_Modifiers: Modifiers
     has_many_OrderStatusLogs: 'Order Status Logs'

--- a/lang/hr.yml
+++ b/lang/hr.yml
@@ -211,6 +211,7 @@ hr:
     ShipTo: 'Pošalji na'
     SubTotal: Međuzbroj
     Total: Ukupno
+    TotalNice: Ukupno
     TotalOutstanding: 'Ukupno nepodmireno'
     TotalPrice: 'Ukupna cijena'
     TotalPriceWithCurrency: 'Ukupna cijena ({Currency})'

--- a/lang/nb.yml
+++ b/lang/nb.yml
@@ -243,6 +243,7 @@ nb:
     ShipTo: 'Send til'
     SubTotal: Sum total
     Total: Pris
+    TotalNice: Pris
     TotalOutstanding: 'Total utestående'
     TotalPrice: 'Pris'
     TotalPriceWithCurrency: 'Pris  ({Currency})'

--- a/lang/nl.yml
+++ b/lang/nl.yml
@@ -243,6 +243,7 @@ nl:
     ShipTo: 'Verzend naar'
     SubTotal: Subtotaal
     Total: Totaal
+    TotalNice: Totaal
     TotalOutstanding: 'Totaal openstaand'
     TotalPrice: 'Totaalprijs'
     TotalPriceWithCurrency: 'Totaalprijs ({Currency})'

--- a/lang/nn.yml
+++ b/lang/nn.yml
@@ -241,6 +241,7 @@ nn:
     ShipTo: 'Send sending til:'
     SubTotal: Sum total
     Total: Total
+    TotalNice: Total
     TotalOutstanding: 'Total uteståande'
     TotalPrice: 'Total pris'
     TotalPriceWithCurrency: 'Total pris ({Currency})'

--- a/src/Model/Modifiers/OrderModifier.php
+++ b/src/Model/Modifiers/OrderModifier.php
@@ -49,7 +49,7 @@ class OrderModifier extends OrderAttribute
         'Order.ID' => 'Order ID',
         'TableTitle' => 'Table Title',
         'ClassName' => 'Type',
-        'Amount' => 'Amount',
+        'Amount.Nice' => 'Amount',
         'Type' => 'Type',
     ];
 
@@ -121,24 +121,24 @@ class OrderModifier extends OrderAttribute
         return true;
     }
 
-    /**
-     * This function is always called to determine the
-     * amount this modifier needs to charge or deduct.
-     *
-     * If the modifier exists in the DB, in which case it
-     * already exists for a given order, we just return
-     * the Amount data field from the DB. This is for
-     * existing orders.
-     *
-     * If this is a new order, and the modifier doesn't
-     * exist in the DB ($this->ID is 0), so we return
-     * the amount from $this->LiveAmount() which is a
-     * calculation based on the order and it's items.
-     */
-    public function Amount()
-    {
-        return $this->Amount;
-    }
+//    /**
+//     * This function is always called to determine the
+//     * amount this modifier needs to charge or deduct.
+//     *
+//     * If the modifier exists in the DB, in which case it
+//     * already exists for a given order, we just return
+//     * the Amount data field from the DB. This is for
+//     * existing orders.
+//     *
+//     * If this is a new order, and the modifier doesn't
+//     * exist in the DB ($this->ID is 0), so we return
+//     * the amount from $this->LiveAmount() which is a
+//     * calculation based on the order and it's items.
+//     */
+//    public function Amount()
+//    {
+//        return $this->Amount;
+//    }
 
     /**
      * Monetary to use in templates.

--- a/src/Model/Modifiers/OrderModifier.php
+++ b/src/Model/Modifiers/OrderModifier.php
@@ -48,7 +48,7 @@ class OrderModifier extends OrderAttribute
     private static $summary_fields = [
         'Order.ID' => 'Order ID',
         'TableTitle' => 'Table Title',
-        'ClassName' => 'Type',
+        'ClassName.ShortName' => 'Type',
         'Amount.Nice' => 'Amount',
         'Type' => 'Type',
     ];

--- a/src/Model/Order.php
+++ b/src/Model/Order.php
@@ -142,7 +142,7 @@ class Order extends DataObject
         'Placed',
         'Name',
         'LatestEmail',
-        'Total',
+        'TotalNice',
         'StatusI18N',
     ];
 
@@ -343,6 +343,7 @@ class Order extends DataObject
         $labels['Name'] = _t('SilverShop\Generic.Customer', 'Customer');
         $labels['LatestEmail'] = _t(__CLASS__ . '.db_Email', 'Email');
         $labels['StatusI18N'] = _t(__CLASS__ . '.db_Status', 'Status');
+        $labels['TotalNice'] = _t(__CLASS__ . '.TotalNice', 'Total');
 
         return $labels;
     }
@@ -483,6 +484,25 @@ class Order extends DataObject
     }
 
     /**
+     * Helper method for getting nice currency-formatted values.
+     *
+     * This is needed, cause Total() conflicts with casting to Currency.
+     * Related Issue: https://github.com/silvershop/silvershop-core/issues/811
+     *
+     * Can be deprecated and removed once the issue is resolved.
+     *
+     * @return string
+     */
+    public function TotalNice(): string
+    {
+        $total = $this->dbObject('Total');
+        if ($total instanceof DBCurrency) {
+            return $total->Nice();
+        }
+        return '';
+    }
+
+    /**
      * Calculate how much is left to be paid on the order.
      * Enforces rounding precision.
      *
@@ -518,7 +538,7 @@ class Order extends DataObject
     public function Link()
     {
         $link = CheckoutPage::find_link(false, 'order', $this->ID);
-        
+
         if (Security::getCurrentUser()) {
             $link = Controller::join_links(AccountPage::find_link(), 'order', $this->ID);
         }

--- a/src/Reports/AbandonedCartReport.php
+++ b/src/Reports/AbandonedCartReport.php
@@ -29,7 +29,10 @@ class AbandonedCartReport extends ShopPeriodReport
         return [
             'FilterPeriod' => $period,
             'Count' => 'Count',
-            'TotalValue' => 'Total Value',
+            'TotalValue' => [
+                'title' => 'Total Value',
+                'casting' => 'Currency->Nice'
+            ]
         ];
     }
 

--- a/src/Reports/CustomerReport.php
+++ b/src/Reports/CustomerReport.php
@@ -28,7 +28,10 @@ class CustomerReport extends ShopPeriodReport
             'Surname' => 'Surname',
             'Email' => 'Email',
             'Created' => 'Joined',
-            'Spent' => 'Spent',
+            'Spent' => [
+                'title' =>'Spent',
+                'casting' => 'Currency->Nice'
+            ],
             'Orders' => 'Orders',
             'edit' => [
                 'title' => 'Edit',

--- a/src/Reports/ProductReport.php
+++ b/src/Reports/ProductReport.php
@@ -25,9 +25,15 @@ class ProductReport extends ShopPeriodReport
                 'title' => 'Title',
                 'formatting' => '<a href=\"admin/catalog/Product/EditForm/field/Product/item/$ID/edit\" target=\"_new\">$Title</a>',
             ],
-            'BasePrice' => 'Price',
+            'BasePrice' => [
+                'title' => 'Price',
+                'casting' => 'Currency->Nice'
+            ],
             'Quantity' => 'Quantity',
-            'Sales' => 'Sales',
+            'Sales' => [
+                'title' => 'Total Sales',
+                'casting' => 'Currency->Nice'
+            ],
         ];
     }
 

--- a/src/Reports/ShopSalesReport.php
+++ b/src/Reports/ShopSalesReport.php
@@ -31,7 +31,10 @@ class ShopSalesReport extends ShopPeriodReport
         return [
             'FilterPeriod' => $period,
             'Count' => 'Order Count',
-            'Sales' => 'Total Sales',
+            'Sales' => [
+                'title' => 'Total Sales',
+                'casting' => 'Currency->Nice'
+                ],
         ];
     }
 

--- a/src/Reports/TaxReport.php
+++ b/src/Reports/TaxReport.php
@@ -29,8 +29,14 @@ class TaxReport extends ShopPeriodReport
         return [
             'FilterPeriod' => $period,
             'Count' => 'Order Count',
-            'Sales' => 'Total Sales',
-            'Tax' => 'Total Tax',
+            'Sales' => [
+                'title' => 'Total Sales',
+                'casting' => 'Currency->Nice'
+            ],
+            'Tax' => [
+                'title' => 'Total Tax',
+                'casting' => 'Currency->Nice'
+            ]
         ];
     }
 
@@ -41,7 +47,8 @@ class TaxReport extends ShopPeriodReport
                 'SilverShop_OrderAttribute',
                 '"SilverShop_OrderAttribute"."OrderID" = "SilverShop_Order"."ID" AND "SilverShop_OrderAttribute"."ClassName" LIKE \'%TaxModifier\''
             )
-            ->addInnerJoin('SilverShop_OrderModifier', '"SilverShop_OrderModifier"."ID" = "SilverShop_OrderAttribute"."ID"')
+            ->addInnerJoin('SilverShop_OrderModifier',
+                '"SilverShop_OrderModifier"."ID" = "SilverShop_OrderAttribute"."ID"')
             ->selectField('COUNT("SilverShop_Order"."ID")', 'Count')
             ->selectField('SUM("SilverShop_OrderModifier"."Amount")', 'Tax')
             ->selectField('SUM("SilverShop_Order"."Total")', 'Sales');

--- a/src/Reports/TaxReport.php
+++ b/src/Reports/TaxReport.php
@@ -47,8 +47,10 @@ class TaxReport extends ShopPeriodReport
                 'SilverShop_OrderAttribute',
                 '"SilverShop_OrderAttribute"."OrderID" = "SilverShop_Order"."ID" AND "SilverShop_OrderAttribute"."ClassName" LIKE \'%TaxModifier\''
             )
-            ->addInnerJoin('SilverShop_OrderModifier',
-                '"SilverShop_OrderModifier"."ID" = "SilverShop_OrderAttribute"."ID"')
+            ->addInnerJoin(
+                'SilverShop_OrderModifier',
+                '"SilverShop_OrderModifier"."ID" = "SilverShop_OrderAttribute"."ID"'
+            )
             ->selectField('COUNT("SilverShop_Order"."ID")', 'Count')
             ->selectField('SUM("SilverShop_OrderModifier"."Amount")', 'Tax')
             ->selectField('SUM("SilverShop_Order"."Total")', 'Sales');


### PR DESCRIPTION
somehow related to #779 some more formatting for different prices in the backend.

For formatting payments see https://github.com/silverstripe/silverstripe-omnipay/issues/244

@wilr and/or @forsdahl please have a look at this PR and merge if possible. I disabled OrderModifier's Amount() method which should be fine IMHO but could possibly break some stuff.