### PR TITLE
Configuration API

### DIFF
--- a/src/Forms/RestrictionRegionCountryDropdownField.php
+++ b/src/Forms/RestrictionRegionCountryDropdownField.php
@@ -14,6 +14,6 @@ class RestrictionRegionCountryDropdownField extends DropdownField
         $source = SiteConfig::current_site_config()->getCountriesList(true);
         parent::__construct($name, $title, $source, $value);
         $this->setHasEmptyDefault(true);
-        $this->setEmptyString(self::$defaultname);
+        $this->setEmptyString(static::config()->get('defaultname'));
     }
 }

--- a/src/Model/Address.php
+++ b/src/Model/Address.php
@@ -173,14 +173,14 @@ class Address extends DataObject
 
     /**
      * Get an array of data fields that must be populated for model to be valid.
-     * Required fields can be customised via self::$required_fields
+     * Required fields can be customised via private static $required_fields
      */
     public function getRequiredFields()
     {
         $fields = self::config()->required_fields;
         //hack to allow overriding arrays in ss config
-        if (self::$required_fields != $fields) {
-            foreach (self::$required_fields as $requirement) {
+        if (static::config()->get('required_fields') != $fields) {
+            foreach (static::config()->get('required_fields') as $requirement) {
                 if (($key = array_search($requirement, $fields)) !== false) {
                     unset($fields[$key]);
                 }

--- a/src/Model/Order.php
+++ b/src/Model/Order.php
@@ -462,7 +462,7 @@ class Order extends DataObject
      */
     public function setTotal($val)
     {
-        $this->setField('Total', round($val, self::$rounding_precision));
+        $this->setField('Total', round($val, static::config()->get('rounding_precision')));
     }
 
     /**
@@ -807,7 +807,7 @@ class Order extends DataObject
     protected function onBeforeWrite()
     {
         parent::onBeforeWrite();
-        if (!$this->getField('Reference') && in_array($this->Status, self::$placed_status)) {
+        if (!$this->getField('Reference') && in_array($this->Status, static::config()->get('placed_status'))) {
             $this->generateReference();
         }
 

--- a/src/Tasks/ShopMigrationTask.php
+++ b/src/Tasks/ShopMigrationTask.php
@@ -42,15 +42,15 @@ You may want to run the CartCleanupTask before migrating if you want to discard 
     public function migrateOrders()
     {
         $start = $count = 0;
-        $batch = Order::get()->sort('Created', 'ASC')->limit($start, self::$batch_size);
+        $batch = Order::get()->sort('Created', 'ASC')->limit($start, static::config()->get('batch_size'));
         while ($batch->exists()) {
             foreach ($batch as $order) {
                 $this->migrate($order);
                 echo '. ';
                 $count++;
             }
-            $start += self::$batch_size;
-            $batch = $batch->limit($start, self::$batch_size);
+            $start += static::config()->get('batch_size');
+            $batch = $batch->limit($start, static::config()->get('batch_size'));
         };
         echo "$count orders updated.\n<br/>";
     }


### PR DESCRIPTION
Replace the use of self::variable_name with the Configuration API so that properties can be set via config yaml.  Thanks.