### PR TITLE
Provide an option to disable the emailing of receipts

### DIFF
--- a/docs/en/02_Customisation/Emails.md
+++ b/docs/en/02_Customisation/Emails.md
@@ -5,6 +5,9 @@ Shop emails can be customised to suit your project needs.
 There are a few yaml config options that will affect which emails are sent:
 
 ```yaml
+SilverShop\Model\Order:
+  send_receipt: false # to disable the emailing of paid invoices (default is true)
+
 SilverShop\Checkout\OrderProcessor:
   #send order confirmation when order is placed, but unpaid
   send_confirmation: true
@@ -13,6 +16,7 @@ SilverShop\Checkout\OrderProcessor:
 SilverShop\Checkout\OrderEmailNotifier:
   bcc_confirmation_to_admin: true
   bcc_receipt_to_admin: true
+  bcc_status_change_to_admin: true
 
 #Specify the 'from' address to use in email correspondence
 SilverShop\Extension\ShopConfigExtension:
@@ -35,7 +39,7 @@ en:
   ShopEmail:
     ConfirmationSubject: 'My Website Order #{OrderNo} confirmation'
     ReceiptSubject: 'My Website Order #{OrderNo} receipt'
-    CancelSubject: 'My Website Order #{OrderNo} cancelled by member'  
+    CancelSubject: 'My Website Order #{OrderNo} cancelled by member'
 ```
 
 ## Making your own Notifier
@@ -48,4 +52,3 @@ Injector:
   OrderEmailNotifier:
     class: MyCustomOrderEmailNotifier
 ```
-

--- a/example_config.yml
+++ b/example_config.yml
@@ -22,6 +22,7 @@ SilverShop\Model\Order:
   modifiers:
     - 'SilverShop\Model\Modifiers\Shipping\Simple'
     - 'SilverShop\Model\Modifiers\Tax\FlatTax'
+  # send_receipt: false  # send paid invoice to customer (default is true)
   cancel_before_payment: false
   cancel_before_processing: false
   cancel_before_sending: false

--- a/src/Checkout/OrderProcessor.php
+++ b/src/Checkout/OrderProcessor.php
@@ -34,6 +34,16 @@ class OrderProcessor
     use Configurable;
 
     /**
+     * @config
+     */
+    private static bool $send_admin_notification = false;
+
+    /**
+     * @config
+     */
+    private static bool $send_confirmation = false;
+
+    /**
      * @var Order
      */
     protected $order;

--- a/src/Model/Order.php
+++ b/src/Model/Order.php
@@ -216,6 +216,12 @@ class Order extends DataObject
     private static $cancel_before_payment = true;
 
     /**
+     * Email customer an invoice upon payment
+     * @config
+     */
+    private static bool $send_receipt = true;
+
+    /**
      * Whether or not an order can be cancelled before processing
      *
      * @config
@@ -845,7 +851,7 @@ class Order extends DataObject
             //all payment is settled
             $this->extend('onPaid');
 
-            if (!$this->ReceiptSent) {
+            if (!$this->ReceiptSent && static::config()->get('send_receipt')) {
                 OrderEmailNotifier::create($this)->sendReceipt();
                 $this->setField('ReceiptSent', DBDatetime::now()->Rfc2822());
             }

--- a/tests/php/Checkout/OrderEmailNotifierTest.php
+++ b/tests/php/Checkout/OrderEmailNotifierTest.php
@@ -54,6 +54,19 @@ class OrderEmailNotifierTest extends SapphireTest
         $this->assertEmailSent('test@example.com', 'shop-admin@example.com');
     }
 
+    public function testReceiptNoEmailSent()
+    {
+        $this->clearEmails();
+        Config::modify()->set(Order::class, 'send_receipt', false);
+        $order = $this->objFromFixture(Order::class, 'unpaid');
+        $order->setField('Status', 'Paid');
+        $order->write();
+        $this->assertNull(
+            $this->findEmail('hi@there.net', 'shop-admin@example.com'),
+            'An email is not sent when the Order class send_receipt is set to false'
+        );
+    }
+
     public function testStatusUpdate()
     {
         $this->notifier->sendStatusChange('test subject');


### PR DESCRIPTION
For when a site is only using the Manual payment method (confirmation email has already been sent to the customer) and a second email upon payment is not needed.  Thanks.