### PR TITLE
Replace boolean with bool

### DIFF
--- a/src/Cart/OrderTotalCalculator.php
+++ b/src/Cart/OrderTotalCalculator.php
@@ -130,7 +130,7 @@ class OrderTotalCalculator
      * or created if it is always required.
      *
      * @param string  $className
-     * @param boolean $forcecreate - force the modifier to be created.
+     * @param bool $forcecreate - force the modifier to be created.
      */
     public function getModifier($className, $forcecreate = false)
     {

--- a/src/Cart/ShoppingCart.php
+++ b/src/Cart/ShoppingCart.php
@@ -246,7 +246,7 @@ class ShoppingCart
      *
      * @param int $quantity - number of items to remove, or leave null for all items (default)
      * @param array $filter
-     * @return boolean success/failure
+     * @return bool success/failure
      */
     public function remove(Buyable $buyable, $quantity = null, $filter = []): ?bool
     {

--- a/src/Checkout/CheckoutComponentConfig.php
+++ b/src/Checkout/CheckoutComponentConfig.php
@@ -152,7 +152,7 @@ class CheckoutComponentConfig
      * Validate every component against given data.
      *
      * @param array $data data to validate
-     * @return boolean validation result
+     * @return bool validation result
      * @throws ValidationException
      */
     public function validateData(array $data): bool

--- a/src/Checkout/Component/CheckoutComponent.php
+++ b/src/Checkout/Component/CheckoutComponent.php
@@ -52,7 +52,7 @@ abstract class CheckoutComponent
      * @param array $data  data to be validated
      *
      * @throws ValidationException
-     * @return boolean the data is valid
+     * @return bool the data is valid
      */
     abstract public function validateData(Order $order, array $data): bool;
 

--- a/src/Checkout/OrderProcessor.php
+++ b/src/Checkout/OrderProcessor.php
@@ -258,7 +258,7 @@ class OrderProcessor
     /**
      * Takes an order from being a cart to awaiting payment.
      *
-     * @return boolean - success/failure
+     * @return bool - success/failure
      */
     public function placeOrder(): bool
     {

--- a/src/Extension/ShopConfigExtension.php
+++ b/src/Extension/ShopConfigExtension.php
@@ -131,7 +131,7 @@ class ShopConfigExtension extends Extension
     /**
      * Get list of allowed countries
      *
-     * @param boolean $prefixisocode - prefix the country code
+     * @param bool $prefixisocode - prefix the country code
      */
     public function getCountriesList($prefixisocode = false): array
     {

--- a/src/Model/Buyable.php
+++ b/src/Model/Buyable.php
@@ -31,7 +31,7 @@ interface Buyable
      *
      * @param  Member|null $member   the Member that wants to purchase the buyable. Defaults to null
      * @param  int         $quantity the quantity to purchase. Defaults to 1
-     * @return boolean true if the buyable can be purchased
+     * @return bool true if the buyable can be purchased
      */
     public function canPurchase(?Member $member = null, int $quantity = 1): bool;
 

--- a/src/Model/Order.php
+++ b/src/Model/Order.php
@@ -749,7 +749,7 @@ class Order extends DataObject
      */
     public function IsPaid(): bool
     {
-        return (boolean)$this->Paid || $this->Status == 'Paid';
+        return (bool)$this->Paid || $this->Status == 'Paid';
     }
 
     public function IsCart(): bool

--- a/src/Model/Product/OrderItem.php
+++ b/src/Model/Product/OrderItem.php
@@ -38,7 +38,7 @@ class OrderItem extends \SilverShop\Model\OrderItem
      *  - live version if in cart, or
      *  - historical version if order is placed
      *
-     * @param boolean $forcecurrent - force getting latest version of the product.
+     * @param bool $forcecurrent - force getting latest version of the product.
      */
     public function Product(bool $forcecurrent = false): DataObject|Versioned|null
     {

--- a/src/Model/Variation/OrderItem.php
+++ b/src/Model/Variation/OrderItem.php
@@ -33,7 +33,7 @@ class OrderItem extends \SilverShop\Model\Product\OrderItem
     /**
      * Overloaded relationship, for getting versioned variations
      *
-     * @param  boolean $forcecurrent
+     * @param  bool $forcecurrent
      */
     public function ProductVariation($forcecurrent = false): DataObject|Versioned|null
     {

--- a/src/Model/Variation/Variation.php
+++ b/src/Model/Variation/Variation.php
@@ -348,7 +348,7 @@ class Variation extends DataObject implements Buyable
 
     /*
      * Returns if the product variation is already in the shopping cart.
-     * @return boolean
+     * @return bool
      */
     public function IsInCart(): bool
     {

--- a/src/ORM/OrderItemList.php
+++ b/src/ORM/OrderItemList.php
@@ -26,7 +26,7 @@ class OrderItemList extends HasManyList
      * Optionally sum product field instead.
      *
      * @param string  $field     - field to sum
-     * @param boolean $onproduct - sum from product or not
+     * @param bool $onproduct - sum from product or not
      *
      * @return float sum total of field
      */

--- a/src/Page/AccountPage.php
+++ b/src/Page/AccountPage.php
@@ -29,7 +29,7 @@ class AccountPage extends Page
     /**
      * Returns the link or the URLSegment to the account page on this site
      *
-     * @param boolean $urlSegment Return the URLSegment only
+     * @param bool $urlSegment Return the URLSegment only
      *
      * @return mixed
      */
@@ -43,7 +43,7 @@ class AccountPage extends Page
      * Return a link to view the order on the account page.
      *
      * @param int|string $orderID    ID of the order
-     * @param boolean    $urlSegment Return the URLSegment only
+     * @param bool    $urlSegment Return the URLSegment only
      */
     public static function get_order_link($orderID, $urlSegment = false): string
     {

--- a/src/Page/CartPage.php
+++ b/src/Page/CartPage.php
@@ -34,7 +34,7 @@ class CartPage extends Page
     /**
      * Returns the link to the checkout page on this site
      *
-     * @param boolean $urlSegment If set to TRUE, only returns the URLSegment field
+     * @param bool $urlSegment If set to TRUE, only returns the URLSegment field
      *
      * @return string Link to checkout page
      */

--- a/src/Page/CheckoutPage.php
+++ b/src/Page/CheckoutPage.php
@@ -39,7 +39,7 @@ class CheckoutPage extends Page
     /**
      * Returns the link to the checkout page on this site
      *
-     * @param boolean $urlSegment If set to TRUE, only returns the URLSegment field
+     * @param bool $urlSegment If set to TRUE, only returns the URLSegment field
      */
     public static function find_link($urlSegment = false, $action = null, $id = null): string
     {

--- a/tests/php/Cart/ShoppingCartTest.php
+++ b/tests/php/Cart/ShoppingCartTest.php
@@ -50,13 +50,13 @@ final class ShoppingCartTest extends SapphireTest
 
     public function testAddToCart(): void
     {
-        $this->assertTrue((boolean)$this->cart->add($this->product), "add one item");
+        $this->assertTrue((bool)$this->cart->add($this->product), "add one item");
         $this->assertEquals(
             ['onStartOrder', 'beforeAdd', 'afterAdd'],
             ShoppingCartTest_TestShoppingCartHooksExtension::$stack
         );
 
-        $this->assertTrue((boolean)$this->cart->add($this->product), "add another item");
+        $this->assertTrue((bool)$this->cart->add($this->product), "add another item");
         $this->assertEquals(
             ['onStartOrder', 'beforeAdd', 'afterAdd', 'beforeAdd', 'afterAdd'],
             ShoppingCartTest_TestShoppingCartHooksExtension::$stack
@@ -74,7 +74,7 @@ final class ShoppingCartTest extends SapphireTest
 
     public function testRemoveFromCart(): void
     {
-        $this->assertTrue((boolean)$this->cart->add($this->product), "add item");
+        $this->assertTrue((bool)$this->cart->add($this->product), "add item");
         $this->assertEquals(
             ['onStartOrder', 'beforeAdd', 'afterAdd'],
             ShoppingCartTest_TestShoppingCartHooksExtension::$stack
@@ -92,7 +92,7 @@ final class ShoppingCartTest extends SapphireTest
 
     public function testSetQuantity(): void
     {
-        $this->assertTrue((boolean)$this->cart->setQuantity($this->product, 25), "quantity set");
+        $this->assertTrue((bool)$this->cart->setQuantity($this->product, 25), "quantity set");
 
         $this->assertEquals(
             ['onStartOrder', 'beforeSetQuantity', 'afterSetQuantity'],
@@ -105,8 +105,8 @@ final class ShoppingCartTest extends SapphireTest
 
     public function testClear(): void
     {
-        $this->assertTrue((boolean)$this->cart->add($this->product), "add one item");
-        $this->assertTrue((boolean)$this->cart->add($this->product), "add another item");
+        $this->assertTrue((bool)$this->cart->add($this->product), "add one item");
+        $this->assertTrue((bool)$this->cart->add($this->product), "add another item");
         $this->assertInstanceOf(Order::class, $this->cart->current(), "there's a cart");
         $this->assertTrue($this->cart->clear(), "clear the cart");
         $this->assertFalse((bool)$this->cart->current(), "there is no cart");
@@ -114,7 +114,7 @@ final class ShoppingCartTest extends SapphireTest
 
     public function testCartSingleton(): void
     {
-        $this->assertTrue((boolean)$this->cart->add($this->product), "add one item");
+        $this->assertTrue((bool)$this->cart->add($this->product), "add one item");
         $order = $this->cart->current();
 
         $this->assertEquals($order->ID, ShoppingCart::curr()->ID, "if singleton order ids will match");
@@ -127,19 +127,19 @@ final class ShoppingCartTest extends SapphireTest
         ShoppingCart::singleton()->clear();
         $shoppingCart = ShoppingCart::singleton();
 
-        $this->assertTrue((boolean)$this->cart->add($this->product, 1), "add one item");
+        $this->assertTrue((bool)$this->cart->add($this->product, 1), "add one item");
         $item = $shoppingCart->get($this->product);
         $this->assertFalse(
-            (boolean)$this->cart->add($this->product, 1),
+            (bool)$this->cart->add($this->product, 1),
             "Cannot add more than one item, extension will error"
         );
         $this->assertEquals($item->Quantity, 1, "quantity is 1");
 
-        $this->assertTrue((boolean)$shoppingCart->setQuantity($this->product, 10), "quantity set");
+        $this->assertTrue((bool)$shoppingCart->setQuantity($this->product, 10), "quantity set");
         $item = $shoppingCart->get($this->product);
         $this->assertEquals($item->Quantity, 10, "quantity is 10");
 
-        $this->assertFalse((boolean)$shoppingCart->setQuantity($this->product, 11), "Cannot set quantity to more than 10 items");
+        $this->assertFalse((bool)$shoppingCart->setQuantity($this->product, 11), "Cannot set quantity to more than 10 items");
         $item = $shoppingCart->get($this->product);
         $this->assertEquals($item->Quantity, 10, "quantity is 10");
     }
@@ -152,14 +152,14 @@ final class ShoppingCartTest extends SapphireTest
         /** @var Variation $ball2 */
         $ball2 = $this->objFromFixture(Variation::class, 'redSmall');
 
-        $this->assertTrue((boolean)$this->cart->add($variation), "add one item");
+        $this->assertTrue((bool)$this->cart->add($variation), "add one item");
 
         $this->assertEquals(
             ['onStartOrder', 'beforeAdd', 'afterAdd'],
             ShoppingCartTest_TestShoppingCartHooksExtension::$stack
         );
 
-        $this->assertTrue((boolean)$this->cart->add($ball2), "add another item");
+        $this->assertTrue((bool)$this->cart->add($ball2), "add another item");
         $this->assertTrue($this->cart->remove($variation), "remove first item");
 
         $this->assertEquals(

--- a/tests/php/Checkout/OrderProcessorTest.php
+++ b/tests/php/Checkout/OrderProcessorTest.php
@@ -92,7 +92,7 @@ final class OrderProcessorTest extends SapphireTest
         $order = $this->objFromFixture(Order::class, "unpaid");
         $orderProcessor = OrderProcessor::create($order);
         $payment = $orderProcessor->createPayment('Dummy');
-        $this->assertTrue((boolean)$payment);
+        $this->assertTrue((bool)$payment);
     }
 
     public function testPlaceOrder(): void
@@ -282,7 +282,7 @@ final class OrderProcessorTest extends SapphireTest
         );
 
         $order = Order::get()->byID($cart->ID);
-        $this->assertTrue((boolean)$order, 'Order exists');
+        $this->assertTrue((bool)$order, 'Order exists');
         $this->assertEquals($order->Status, 'Unpaid', 'status is now "unpaid"');
         $this->assertEquals($order->FirstName, 'Joseph', 'order first name');
         $this->assertEquals($order->Surname, 'Blog', 'order surname');
@@ -329,7 +329,7 @@ final class OrderProcessorTest extends SapphireTest
         $this->assertTrue($success, 'Non-member order placed successfully ...' . $error);
 
         $order = Order::get()->byID($order->ID); //update $order
-        $this->assertTrue((boolean)$order, 'Order exists');
+        $this->assertTrue((bool)$order, 'Order exists');
         $this->assertEquals($order->Status, 'Unpaid', 'status is now "unpaid"');
         $this->assertEquals($order->MemberID, 0, 'No associated member');
         $this->assertEquals($order->GrandTotal(), 8, 'grand total');

--- a/tests/php/Extension/SteppedCheckoutExtensionTest.php
+++ b/tests/php/Extension/SteppedCheckoutExtensionTest.php
@@ -121,7 +121,7 @@ final class SteppedCheckoutExtensionTest extends FunctionalTest
         $this->post('/checkout/CreateAccountForm', $data); //redirect to next step
 
         $member = MemberExtension::get_by_identifier("mb@example.com");
-        $this->assertTrue((boolean)$member, "Check new account was created");
+        $this->assertTrue((bool)$member, "Check new account was created");
         $this->assertEquals('Michael', $member->FirstName);
         $this->assertEquals('Black', $member->Surname);
     }

--- a/tests/php/Model/OrderTest.php
+++ b/tests/php/Model/OrderTest.php
@@ -359,7 +359,7 @@ final class OrderTest extends SapphireTest
             OrderTest_TestStatusChangeExtension::$stack
         );
 
-        $this->assertTrue((boolean)$order->Paid, 'Order paid date should be set');
+        $this->assertTrue((bool)$order->Paid, 'Order paid date should be set');
     }
 
     public function testGetNameExtensionHook(): void

--- a/tests/php/Page/AccountPageTest.php
+++ b/tests/php/Page/AccountPageTest.php
@@ -96,8 +96,8 @@ final class AccountPageTest extends FunctionalTest
         $defaultform = $forms['DefaultAddressForm'];
         $this->assertTrue($member->AddressBook()->exists());
 
-        $this->assertTrue((boolean)$createform, "Create form exists");
-        $this->assertTrue((boolean)$defaultform, "Default form exists");
+        $this->assertTrue((bool)$createform, "Create form exists");
+        $this->assertTrue((bool)$defaultform, "Default form exists");
 
         $page = $this->get('account/addressbook');
         $this->assertEquals(200, $page->getStatusCode(), 'a page should load');


### PR DESCRIPTION
In php 8.5, non-canonical cast (boolean) is deprecated, use the (bool) cast instead.  Thanks.