### PR TITLE
Update qty in cart gives whitescreen of death

### DIFF
--- a/src/Page/CartPageController.php
+++ b/src/Page/CartPageController.php
@@ -210,7 +210,7 @@ class CartPageController extends PageController
             'remove', 'removeitem' => 'remove',
             'removeall', 'removeallitem' => 'removeall',
             'setquantity', 'setquantityitem' => 'setquantity',
-            'addvariations', 'switchvariation', 'clear', 'debug', 'updatecart', 'cartform' => $a === 'cartform' ? 'CartForm' : $a,
+            'addvariations', 'switchvariation', 'clear', 'debug', 'updatecart' => $a,
             default => null,
         };
     }


### PR DESCRIPTION
The directorActionToCartMethod() match statement was mapping 'cartform' to 'CartForm', which caused the custom dispatch to intercept form POST submissions.

InSS6, form submissions need to go through parent::handleRequest() → FormRequestHandler::httpSubmission() to properly dispatch to action handlers like updatecart(). 

Removing 'cartform' from the match lets it fall through to default => null, so the standard SS6 form machinery handles it