### PR TITLE
Fix CartEditField variation guard for non-variation custom buyables

### DIFF
--- a/src/Forms/CartEditField.php
+++ b/src/Forms/CartEditField.php
@@ -135,7 +135,7 @@ class CartEditField extends FormField
             );
 
             $variationfield = false;
-            if ($buyable->hasMany('Variations')) {
+            if ($buyable->hasMethod('Variations')) {
                 $variations = $buyable->Variations();
                 if ($variations->exists()) {
                     $variationfield = DropdownField::create(

--- a/tests/php/Forms/BuyableWithRelation.php
+++ b/tests/php/Forms/BuyableWithRelation.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SilverShop\Tests\Forms;
+
+use SilverShop\Model\Buyable;
+use SilverShop\Model\OrderItem;
+use SilverStripe\Core\Injector\Injector;
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+use SilverStripe\Security\Member;
+
+/**
+ * A custom buyable that is NOT variation-capable but DOES declare an unrelated
+ * has_many relation.
+ *
+ * This is the shape that trips {@see \SilverShop\Forms\CartEditField}: the field
+ * used to guard variation rendering with `$buyable->hasMany('Variations')`, but
+ * {@see DataObject::hasMany()} takes a `$classOnly` flag — not a component name —
+ * so any non-empty has_many made the guard truthy and led to a call to the
+ * non-existent `Variations()` method.
+ */
+class BuyableWithRelation extends DataObject implements Buyable, TestOnly
+{
+    private static array $db = [
+        'Title' => 'Varchar',
+        'Price' => 'Currency',
+    ];
+
+    // An unrelated has_many — enough to make the buggy hasMany('Variations')
+    // guard return truthy even though this buyable has no Variations relation.
+    private static array $has_many = [
+        'Notes' => BuyableWithRelation_Note::class,
+    ];
+
+    private static string $order_item = BuyableWithRelation_OrderItem::class;
+
+    private static string $table_name = 'SilverShop_Test_BuyableWithRelation';
+
+    public function createItem(int $quantity = 1, array $filter = []): OrderItem
+    {
+        $item = Injector::inst()->create(BuyableWithRelation_OrderItem::class);
+        $item->BuyableWithRelationID = $this->ID;
+        $item->Quantity = $quantity;
+
+        if ($filter !== []) {
+            $item->update($filter);
+        }
+
+        return $item;
+    }
+
+    public function canPurchase(?Member $member = null, int $quantity = 1): bool
+    {
+        return $this->Price > 0;
+    }
+
+    public function sellingPrice(): float
+    {
+        return $this->Price;
+    }
+}

--- a/tests/php/Forms/BuyableWithRelation_Note.php
+++ b/tests/php/Forms/BuyableWithRelation_Note.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SilverShop\Tests\Forms;
+
+use SilverStripe\Dev\TestOnly;
+use SilverStripe\ORM\DataObject;
+
+/**
+ * Child of {@see BuyableWithRelation} — exists only to give the buyable a
+ * non-empty has_many relation for the CartEditField regression test.
+ */
+class BuyableWithRelation_Note extends DataObject implements TestOnly
+{
+    private static array $db = [
+        'Body' => 'Text',
+    ];
+
+    private static array $has_one = [
+        'BuyableWithRelation' => BuyableWithRelation::class,
+    ];
+
+    private static string $table_name = 'SilverShop_Test_BuyableWithRelation_Note';
+}

--- a/tests/php/Forms/BuyableWithRelation_OrderItem.php
+++ b/tests/php/Forms/BuyableWithRelation_OrderItem.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SilverShop\Tests\Forms;
+
+use SilverShop\Model\OrderItem;
+use SilverStripe\Dev\TestOnly;
+
+class BuyableWithRelation_OrderItem extends OrderItem implements TestOnly
+{
+    private static array $has_one = [
+        'BuyableWithRelation' => BuyableWithRelation::class,
+    ];
+
+    private static string $buyable_relationship = 'BuyableWithRelation';
+
+    private static string $table_name = 'SilverShop_Test_BuyableWithRelation_OrderItem';
+
+    public function UnitPrice()
+    {
+        if ($this->BuyableWithRelation()->exists()) {
+            return $this->BuyableWithRelation()->Price;
+        }
+
+        return 0;
+    }
+}

--- a/tests/php/Forms/CartEditFieldTest.php
+++ b/tests/php/Forms/CartEditFieldTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SilverShop\Tests\Forms;
+
+use SilverShop\Cart\ShoppingCart;
+use SilverShop\Forms\CartEditField;
+use SilverStripe\Dev\SapphireTest;
+
+/**
+ * Regression coverage for {@see CartEditField} rendering carts that contain
+ * custom buyables which are not variation-capable.
+ */
+final class CartEditFieldTest extends SapphireTest
+{
+    protected $usesDatabase = true;
+
+    protected static $extra_dataobjects = [
+        BuyableWithRelation::class,
+        BuyableWithRelation_Note::class,
+        BuyableWithRelation_OrderItem::class,
+    ];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        ShoppingCart::singleton()->clear();
+    }
+
+    /**
+     * A buyable with an unrelated has_many (but no Variations relation) must not
+     * cause CartEditField to call a non-existent Variations() method.
+     *
+     * Previously the field guarded variation rendering with
+     * `$buyable->hasMany('Variations')`; because DataObject::hasMany() treats its
+     * argument as a `$classOnly` flag rather than a component name, any non-empty
+     * has_many returned truthy and led to a BadMethodCallException.
+     */
+    public function testFieldRendersForBuyableWithoutVariations(): void
+    {
+        $buyable = BuyableWithRelation::create();
+        $buyable->Title = 'Charge';
+        $buyable->Price = 30;
+        $buyable->write();
+
+        $cart = ShoppingCart::singleton();
+        $this->assertTrue((bool) $cart->add($buyable), 'buyable added to cart');
+
+        $order = $cart->current();
+
+        $field = CartEditField::create('Cart', 'Cart', $order);
+
+        // Before the fix this threw:
+        // BadMethodCallException: the method 'Variations' does not exist
+        $html = (string) $field->Field();
+
+        $this->assertNotSame('', $html, 'CartEditField renders non-empty output');
+    }
+}


### PR DESCRIPTION
## Problem

`CartEditField::editableItems()` guards variation rendering with:

```php
if ($buyable->hasMany('Variations')) {
    $variations = $buyable->Variations();
    ...
}
```

`DataObject::hasMany()` takes a `$classOnly` bool flag, **not** a component
name:

```php
public function hasMany($classOnly = true)
```

So `'Variations'` is passed as a truthy `$classOnly`, and the call returns the
buyable's **entire** `has_many` map. That is non-empty (truthy) for any buyable
that declares *any* `has_many` relation — at which point `$buyable->Variations()`
is invoked unconditionally and throws on buyables that are not variation-capable:

```
BadMethodCallException: Object->__call(): the method 'Variations'
does not exist on '<CustomBuyable>'
```

`Product` masks the bug because it genuinely has a `Variations()` method (via
`ProductVariationsExtension`). Any custom `Buyable` with an unrelated `has_many`
and no variations fatals when rendered in the cart.

## Fix

Guard with `hasMethod('Variations')` — the buyable is only asked for variations
when it can actually provide them. This matches the custom-buyable hardening
already merged in #876 (e.g. `OrderItem::Image()` uses `hasMethod('Image')`).

## Tests

Adds `CartEditFieldTest` plus a minimal custom buyable (`BuyableWithRelation`)
that declares an unrelated `has_many` but no `Variations`. The test renders the
field for a cart containing that buyable.

- Fails on current `main` with the exact `BadMethodCallException` above.
- Passes with the fix.

`composer lint` and the new test both pass on PHP 8.4.
